### PR TITLE
licence(A5/#7): normalise malformed PMPL SPDX values (owner carve-out, SPDX-only)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: PMPL-1.0-or-later
 name: CodeQL Security Analysis
 
 on:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: PMPL-1.0-or-later
 name: OSSF Scorecard
 on:
   push:

--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Prevention workflow - scans for hardcoded secrets before they reach main
 name: Secret Scanner
 

--- a/contractiles/must/Mustfile
+++ b/contractiles/must/Mustfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PLMP-1.0-or-later
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Mustfile - mandatory checks
 # See: https://github.com/hyperpolymath/mustfile
 


### PR DESCRIPTION
4 files. PLMP/PMLP + doubled + bare -> canonical PMPL-1.0-or-later. SPDX-value-only, NOT a relicence. Owner-sanctioned A8(1)+A5. Refs LICENCE-DEBT-LEDGER-2026-05-18. 🤖 Generated with [Claude Code](https://claude.com/claude-code)