### PR TITLE
chore(linguist): exclude Python from language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -53,3 +53,5 @@ Containerfile  text eol=lf
 # Lock files
 Cargo.lock  text eol=lf -diff
 flake.lock  text eol=lf -diff
+# Pending estate-wide policy: hide Python from primary-language detection.
+**/*.py linguist-detectable=false


### PR DESCRIPTION
## Summary
Adds `**/*.py linguist-detectable=false` to `.gitattributes` so Python files do not dominate GitHub's primary-language detection.

**Rationale**: Estate-wide policy: Python is banned outside SaltStack contexts. Pending eradication (issue tracked separately); this PR is the immediate cosmetic fix to stop the language showing up in GitHub's primary-language detection.

## Changes
- `.gitattributes`: `**/*.py linguist-detectable=false`

Part of estate-wide metadata cleanup 2026-05-26.