### PR TITLE
ci(formal): Idris2 ABI typecheck (digest-pinned) + wire AxiomSMTExt + state currency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,18 @@ jobs:
           path: build/proof_bundle_evidence.json
           if-no-files-found: warn
 
+  idris2-abi-check:
+    name: Idris2 ABI typecheck
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/stefan-hoeck/idris2-pack@sha256:de9781906050dc44704ec6de0108c86f899ef17b2642932b79e00245d613b8ad
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Typecheck ABI package (Abi.Types, Abi.Layout, Abi.Foreign)
+        run: idris2 --typecheck axiom-abi.ipkg
+
   smt-proofs:
     name: SMT proofs (Z3)
     runs-on: ubuntu-latest
@@ -553,6 +565,11 @@ jobs:
 
       - name: SMTLib.jl subpackage tests (solver-backed)
         run: julia --project=packages/SMTLib.jl -e 'using Pkg; Pkg.instantiate(); Pkg.test()'
+
+      - name: AxiomSMTExt loads (extension wiring) + report Axiom SMT solver
+        run: |
+          julia --project=. -e 'using Pkg; Pkg.develop(path="packages/SMTLib.jl"); Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
+          julia --project=. -e 'using Axiom, SMTLib; ext = Base.get_extension(Axiom, :AxiomSMTExt); ext === nothing && error("AxiomSMTExt did not load after wiring"); println("AxiomSMTExt loaded: ", ext); println("Axiom.get_smt_solver() => ", Axiom.get_smt_solver())'
 
   docs-sanity:
     name: Documentation sanity

--- a/.machine_readable/6a2/STATE.a2ml
+++ b/.machine_readable/6a2/STATE.a2ml
@@ -5,7 +5,7 @@
 [metadata]
 project = "Axiom.jl"
 version = "1.0.0"
-last-updated = "2026-06-13"
+last-updated = "2026-06-15"
 status = "active"
 
 [project-context]
@@ -50,7 +50,7 @@ core = [
   "Optimizers (SGD, Adam, AdamW)",
   "Loss functions (mse_loss, crossentropy, binary_crossentropy)",
   "DataLoader with batching and train/test split",
-  "Coprocessor detection + compilation (TPU/NPU/DSP/FPGA/GPU extension paths)",
+  "Coprocessor detection: env-probed strategy (TPU/NPU/PPU/MATH/FPGA/DSP); GPU acceleration via CUDA/AMDGPU/Metal extensions",
   "Serving APIs: REST (serve_rest), GraphQL (serve_graphql), gRPC (serve_grpc, binary wire)",
   "Model interop: PyTorch import (from_pytorch), ONNX export (to_onnx)",
   "Formal verification: @axiom macro, @ensure macro, ValidProbabilities property, certificate workflow",
@@ -60,17 +60,12 @@ extensions = [
   "AxiomCUDAExt (CUDA.jl)",
   "AxiomAMDGPUExt (AMDGPU.jl)",
   "AxiomMetalExt (Metal.jl)",
-  "AxiomTPUExt (TPUCompute)",
-  "AxiomNPUExt (NPUAccel)",
-  "AxiomDSPExt (DSPLibs)",
-  "AxiomFPGAExt (FPGASynthesis)",
-  "AxiomPPUExt (PPUCompute)",
-  "AxiomQPUExt (QPUInterface)",
-  "AxiomVPUExt (VPURuntime)",
-  "AxiomMathExt (MathAccel)",
-  "AxiomCryptoExt (CryptoAccel)",
   "AxiomPyTorchExt (PyCall)",
+  "AxiomSMTExt (SMTLib)",
 ]
+# NOTE 2026-06-15: the 9 placeholder-UUID accelerator extensions
+# (TPU/NPU/DSP/FPGA/PPU/QPU/VPU/Math/Crypto) were removed; AxiomSMTExt was
+# wired into [extensions] (was a dormant ext/ file). 5 real extensions now.
 
 [governance]
 machine-readable-layout = "06-12 estate standard (flat contractiles, bot_directives trio, self-validating/)"

--- a/.machine_readable/bot_directives/debt.a2ml
+++ b/.machine_readable/bot_directives/debt.a2ml
@@ -50,3 +50,10 @@ last-updated = "2026-03-24"
 # effort = "easy"
 # impact = "low"
 # discovered = "2026-03-23"
+
+[[debt.could]]
+component = "zig/src/conv.zig (im2col)"
+issue = "im2col weight column index uses the pre-fix (C_out-outermost) layout — same bug class as the axiom_conv2d kernel fixed 2026-06-14. Harmless today (im2col is not on the axiom_conv2d path), but would mis-pack if wired to a GEMM conv."
+effort = "easy"
+impact = "low"
+discovered = "2026-06-14"

--- a/Project.toml
+++ b/Project.toml
@@ -23,12 +23,14 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+SMTLib = "7d3f9a2c-8b4e-5c1f-a6d0-9e8f7b2c3d4e"
 
 [extensions]
 AxiomAMDGPUExt = "AMDGPU"
 AxiomCUDAExt = "CUDA"
 AxiomMetalExt = "Metal"
 AxiomPyTorchExt = "PyCall"
+AxiomSMTExt = "SMTLib"
 
 [compat]
 Dates = "1"

--- a/axiom-abi.ipkg
+++ b/axiom-abi.ipkg
@@ -1,0 +1,14 @@
+-- SPDX-License-Identifier: MPL-2.0
+-- Idris2 package for the Axiom.jl ABI specification layer.
+-- Typechecked in CI (.github/workflows/ci.yml :: idris2-abi-check) to gate the
+-- formal ABI surface (src/Abi/), which was authored but never compiler-checked.
+
+package axiom-abi
+
+sourcedir = "src"
+
+modules = Abi.Types
+        , Abi.Layout
+        , Abi.Foreign
+
+depends = base


### PR DESCRIPTION
## Summary

Three follow-ups from the proofs/toolchain audit, each researched with a verified-patch agent and applied on this branch.

## 1. Idris2 ABI typecheck gate (re-added, properly pinned)

There is **no `setup-idris` GitHub Action** under any owner (verified via `git ls-remote`). So `idris2-abi-check` runs inside the official **`ghcr.io/stefan-hoeck/idris2-pack`** image pinned by **`@sha256:` digest** — estate policy explicitly accepts digest pins, so the workflow security linter passes (unlike the earlier tag-pin). It runs `idris2 --typecheck axiom-abi.ipkg` (verified the correct ipkg flag) over `Abi.Types → Abi.Layout → Abi.Foreign`.

## 2. AxiomSMTExt wired (Axiom's main SMT path was dead)

`get_smt_solver()` always returned `nothing` because `AxiomSMTExt` existed only as `ext/AxiomSMTExt.jl`, unregistered. Fix:
- `Project.toml`: add `SMTLib` (the local subpackage) to `[weakdeps]` + `AxiomSMTExt = "SMTLib"` to `[extensions]`.
- **No `[sources]`, no compat bump** — `[sources]` is Julia-1.11-only and would break the 1.10 leg; a registered weakdep+extension is 1.10-safe because the main resolve never *installs* weakdeps (same as the existing AMDGPU/CUDA entries).
- The `smt-proofs` job now `Pkg.develop`s SMTLib and **asserts the extension loads** — isolated to that ubuntu job, so the main 1.10/1.11 matrix is untouched and stays green.

## 3. State currency (bot-memo follow-through)

- `STATE.a2ml`: extensions **13 → 5** (placeholder accelerators removed, AxiomSMTExt added) + coprocessor wording.
- `debt.a2ml`: records the `im2col` weight-layout carry-over (the AxiomSMTExt gap is *fixed* here, so not debt).

## Verification caveats (draft)

- The Idris2 image is a digest-pinned **nightly** (idris2-pack ships no semver releases). The draft CI run is the live verification that the digest pulls and the `.idr` typechecks — if the digest is stale I'll re-pin.
- The `smt-proofs` extension-load step is the live verification that the AxiomSMTExt wiring works end-to-end with Z3 present.

Draft until CI confirms both new gates.

https://claude.ai/code/session_01PWMMxryCcPrAjJ8tuGvygG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWMMxryCcPrAjJ8tuGvygG)_