### PR TITLE
docs(bot-directives): test/ci env-read site + adjudicate #32-#35 never-touch surface changes

### DIFF
--- a/.machine_readable/bot_directives/gitbot-fleet.a2ml
+++ b/.machine_readable/bot_directives/gitbot-fleet.a2ml
@@ -8,7 +8,7 @@ name = "Axiom.jl-gitbot-fleet"
 project = "Axiom.jl"
 schema_version = "1.0"
 repo = "Axiom.jl"
-last-updated = "2026-06-13"
+last-updated = "2026-06-18"
 owner = "hyperpolymath"
 
 [fleet]
@@ -36,6 +36,27 @@ never-touch = [
   "packages/SMTLib.jl/",        # SMTLib subpackage
   ".github/workflows/",         # CI hardening is review-gated, not bot-edited
 ]
+
+# ============================================================
+# Adjudicated modifications to never-touch surfaces.
+# These surfaces are bot-off-limits, but were intentionally modified by
+# maintainer-authorised human sessions (claude/<slug>) and merged after
+# CI-green. Bots must treat them as SETTLED — do not flag as drift or
+# attempt to revert / relitigate.
+# ============================================================
+
+[[adjudications]]
+surfaces = ["zig/", ".github/workflows/", "src/verification/"]
+prs = ["#32", "#33", "#34", "#35"]
+date = "2026-06-18"
+reason = """
+PRs #32-#35 modified these never-touch surfaces under maintainer
+authorisation and merged CI-green: zig/src/conv.zig (conv2d weight-layout
+fix + BatchNorm parity), src/verification/certificates.jl (result.mode
+default), and .github/workflows/ci.yml (zig-build de-dup, Idris2 ABI
+typecheck + SMT gates). Settled, not bot drift. src/Abi/ and
+packages/SMTLib.jl/ were NOT modified.
+"""
 
 # ============================================================
 # Per-bot constraints where Axiom.jl gives a specific reason;

--- a/.machine_readable/bot_directives/hypatia.a2ml
+++ b/.machine_readable/bot_directives/hypatia.a2ml
@@ -8,7 +8,7 @@ name = "Axiom.jl-hypatia"
 project = "Axiom.jl"
 schema_version = "1.0"
 repo = "Axiom.jl"
-last-updated = "2026-06-13"
+last-updated = "2026-06-18"
 owner = "hyperpolymath"
 
 [scanner]
@@ -40,9 +40,11 @@ class = "julia/env-read-in-test"
 path = "test/**"
 status = "test-infrastructure"
 reason = """
-test/runtests.jl reads ENV for coprocessor detection (AXIOM_TPU_AVAILABLE,
-AXIOM_TPU_DEVICE_COUNT, etc.) and restores ENV in finally blocks. This is
-the approved test isolation pattern for hardware-absent CI.
+test/runtests.jl AND the test/ci/*.jl smoke suites (e.g.
+coprocessor_strategy.jl) read ENV for coprocessor detection
+(AXIOM_TPU_AVAILABLE, AXIOM_TPU_DEVICE_COUNT, AXIOM_SMT_CACHE, etc.) and
+restore ENV in finally blocks. This is the approved test isolation pattern
+for hardware-absent CI; path test/** already covers both locations.
 """
 
 # ============================================================


### PR DESCRIPTION
## Summary

Two governance-currency notes for the bot fleet — the bot-memo follow-through from the #32–#35 work. Doc-only edits under `.machine_readable/bot_directives/`.

### `hypatia.a2ml`
The approved `julia/env-read-in-test` pattern also lives in the **`test/ci/*.jl` smoke suites** (e.g. `coprocessor_strategy.jl`, reading `AXIOM_SMT_CACHE`), not just `test/runtests.jl`. The accepted-finding path (`test/**`) already covers it; the reason text is updated so the scanner doesn't treat the `test/ci/` occurrences as a new finding.

### `gitbot-fleet.a2ml`
New `[[adjudications]]` entry recording that PRs **#32–#35 intentionally modified three never-touch surfaces** — `zig/` (conv2d kernel + BatchNorm parity), `src/verification/` (`result.mode`), `.github/workflows/` (zig-build de-dup, Idris2 ABI + SMT gates) — under maintainer authorisation, merged CI-green. Bots must treat these as **settled**, not drift to revert. (`src/Abi/` and `packages/SMTLib.jl/` were *not* touched.)

Both files' `last-updated` bumped to 2026-06-18. No code or CI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWMMxryCcPrAjJ8tuGvygG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWMMxryCcPrAjJ8tuGvygG)_