### PR TITLE
ci(hypatia-scan): repin reusable + grant actions:read (estate hypatia fix)

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -22,8 +22,12 @@ permissions:
   contents: read
   security-events: write
   pull-requests: write
+  # The standards reusable declares actions:read; a caller permissions
+  # block that omits it pins actions to `none`, so the reusable's request
+  # exceeds the grant and the run dies as `startup_failure` (no jobs).
+  actions: read
 
 jobs:
   hypatia:
-    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@97df762107501909f50bb770e9bc200b6c415600
+    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@8e6ba7d4a0890d25425855a77404d4690d0ab4b5  # standards #380; repin from a 0-jobs stale ref (paired with actions:read above)
     secrets: inherit


### PR DESCRIPTION
Fixes the chronically-failing `hypatia-scan` workflow. Two gaps, both required:

1. **Stale pin** — the wrapper pinned `standards/hypatia-scan-reusable.yml@97df762…`, which doesn't resolve → every run failed with **0 jobs**. Repinned to `8e6ba7d4a0890d25425855a77404d4690d0ab4b5` (standards #380, current HEAD).
2. **Missing permission** — the reusable's `permissions:` block declares `actions: read`, but this caller's block omitted it (so `actions` defaulted to `none`). Once the pin resolves, that mismatch makes the run die as `startup_failure`. Added `actions: read`.

**Validated end-to-end on [eclexia#42](https://github.com/hyperpolymath/eclexia/pull/42):** with both changes, hypatia-scan runs the full scan and posts its findings comment (it had been red estate-wide for the reusable-wrapper repos). Same root cause + identical fix here.

Draft / review-gated per the estate `.github/workflows/` policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWMMxryCcPrAjJ8tuGvygG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWMMxryCcPrAjJ8tuGvygG)_