### PR TITLE
Axiom flagship hardening (2) — honest proof claims (G03–G05) + design diary

### DIFF
--- a/ABI-FFI-README.md
+++ b/ABI-FFI-README.md
@@ -2,15 +2,28 @@
 
 This file documents the current ABI/FFI split for Axiom.jl.
 
-## Canonical ABI Spec (Idris2)
+## Idris2 ABI Scaffold (illustrative, not the production ABI proof)
 
-The Idris2 ABI scaffold now lives under:
+The Idris2 ABI scaffold lives under:
 
 - `src/Abi/Types.idr`
 - `src/Abi/Layout.idr`
 - `src/Abi/Foreign.idr`
 
-These modules use concrete `axiom_*` symbol names and no unresolved template placeholders.
+These modules use concrete `axiom_*` symbol names and no unresolved template
+placeholders, but they declare a **generic** lifecycle/callback surface
+(`axiom_init`, `axiom_process`, `axiom_register_callback`, ...) that does
+**not** match the ~36 real Zig kernel exports (`axiom_matmul`, `axiom_relu`,
+`axiom_conv2d`, and the rest of `zig/src/axiom.zig`) actually consumed by
+`src/backends/zig_ffi.jl`. Treat this scaffold as a
+worked illustration of the hyperpolymath ABI-FFI pattern (Idris2 ABI + Zig
+FFI), not as a proof binding Axiom's production kernels. The `Verify.*`
+functions in `Types.idr` are `putStrLn` stubs, not executed proofs.
+
+**ROADMAP (future work, not yet started):** extend the `.idr` declarations
+to cover the real `axiom_*` Zig exports and replace the `Verify` stubs with
+genuine size/alignment/signature proofs checked against `zig/src/axiom.zig`
+and `ffi/zig/include/axiom.h`.
 
 ### Idris2 validation
 
@@ -25,20 +38,55 @@ idris2 --source-dir src --check src/Abi/Foreign.idr
 Current production-tested backend FFI path is Julia <-> Zig:
 
 - Julia bridge: `src/backends/zig_ffi.jl`
-- Zig C ABI exports: `ffi/zig/src/main.zig`
+- Zig C ABI exports: `zig/src/axiom.zig` (compiled to `libaxiom_zig.so` via
+  `zig/build.zig`; this is the artifact CI, benchmarks, and
+  `AXIOM_ZIG_LIB`/`ZigBackend(...)` actually load -- see `.github/workflows/ci.yml`,
+  `benchmark/*.jl`, `README.md`)
 
 This path is covered by CI/readiness checks (backend parity + runtime smoke).
 
-## Zig FFI Status
+## KNOWN ISSUE: orphan second Zig FFI tree (`ffi/zig/` vs `zig/`)
 
-`ffi/zig/` is now concrete (non-template) and exports concrete `axiom_*` symbols:
+There are **two** Zig trees in this repository and they are not the same
+code:
 
-- implementation: `ffi/zig/src/main.zig`
-- build/test entry: `ffi/zig/build.zig`
-- integration coverage: `ffi/zig/test/integration_test.zig`
-- C header: `ffi/zig/include/axiom.h`
+- **`zig/`** (repo root) -- the real, production Zig backend. `zig/src/axiom.zig`
+  exports the ~36 real `axiom_*` kernels (`axiom_matmul`, `axiom_relu`,
+  `axiom_conv2d`, activations, norm, pooling, attention, ...) consumed by
+  `src/backends/zig_ffi.jl` and built into `libaxiom_zig.so`.
+- **`ffi/zig/`** -- a separate, smaller Zig tree (`ffi/zig/src/main.zig`,
+  `ffi/zig/build.zig`, `ffi/zig/include/axiom.h`) that exports **zero**
+  `axiom_*` kernel symbols (`grep -c "export fn axiom_"` = 0) and instead
+  implements a different, generic lifecycle/callback C ABI matching the
+  `src/Abi/*.idr` scaffold's naming (`axiom_init`, `axiom_process`,
+  `axiom_register_callback`, ...). Its header comment even points at
+  `src/abi/Foreign.idr`, a stale/incorrect path (the real directory is
+  `src/Abi/`, capital A) -- further evidence this tree has drifted from the
+  rest of the repo and is not wired into anything Julia actually loads.
 
-Validation:
+**This is flagged, not fixed here.** `ffi/zig/` is not deleted -- it may be
+salvageable as the eventual real implementation backing the `src/Abi/*.idr`
+scaffold (see ROADMAP notes above), but as of this writing it is disconnected
+from both the production Zig backend and the Idris2 ABI's stated symbol
+surface. Anyone relying on "the Zig FFI" should confirm which of the two
+trees they mean; for release/readiness purposes only `zig/` is authoritative
+(next section).
+
+## Zig FFI Status (production: `zig/`)
+
+`zig/` is the sole production-tested native backend and exports concrete
+`axiom_*` symbols (~36, see `TOPOLOGY.md`):
+
+- implementation: `zig/src/axiom.zig`
+- build entry: `zig/build.zig`
+- Julia-side wiring: `src/backends/zig_ffi.jl`
+
+The separate `ffi/zig/` tree (`ffi/zig/src/main.zig`, `ffi/zig/build.zig`,
+`ffi/zig/test/integration_test.zig`, `ffi/zig/include/axiom.h`) is also
+concrete (non-template) and internally self-consistent, but -- per the
+orphan-tree note above -- exports a different, generic `axiom_*` surface
+that is not the production kernel FFI. Its own validation still works
+in isolation:
 
 ```bash
 cd ffi/zig
@@ -55,6 +103,11 @@ zig build test
 
 ## Practical Guidance
 
-For release/readiness decisions, treat the Zig FFI path as authoritative.
-Treat Idris2 ABI files as formal scaffold/specification that now typechecks and
-uses concrete Axiom naming.
+For release/readiness decisions, treat `zig/` + `src/backends/zig_ffi.jl` as
+the authoritative production FFI boundary. Treat the Idris2 `src/Abi/*.idr`
+files as an illustrative ABI-FFI scaffold that typechecks and uses concrete
+Axiom naming, but does **not** prove or specify the production kernel FFI --
+see the ROADMAP notes above for what closing that gap would require. Treat
+`ffi/zig/` as a flagged, currently-disconnected second Zig tree (see
+"KNOWN ISSUE" above) pending a decision on whether to wire it to the
+`src/Abi/*.idr` scaffold, fold it into `zig/`, or retire it.

--- a/docs/design-diary/PEPYS-DESIGN-DIARY.adoc
+++ b/docs/design-diary/PEPYS-DESIGN-DIARY.adoc
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
+= The Samuel Pepys of Design — Axiom.jl Flagship Initiative
+Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+:toc: left
+:sectnums:
+:icons: font
+
+A running, candid design diary for the initiative to make *Axiom.jl* the
+hyperpolymath estate's Julia flagship and measuring-stick, with the
+*julia-professional-registry* infrastructure and the *julianiser* tooling
+ultra-completed around it. In the spirit of Pepys: dated entries, honest about
+what was tried, what worked, what didn't, and why each decision was taken.
+
+Doctrine in force (from `standards`, `rsr-template-repo`, `cicd-squabbler`):
+holes-before-features; fixes-first-on-firm-foundations; fail-loudly-seal-soundly;
+distrust-the-neural-for-exactness; squabble-don't-bypass; *no automated licence
+edits — ever*; wire-first; report-faithfully-no-overclaim; stop-first on
+costly/outward-facing actions; boundaries are real (IS / IS-NOT).
+
+Orchestration model for this initiative (the agentic-design demonstration):
+*Opus (me) orchestrates and synthesises*; *Sonnet* runs the deep repo audits and
+web research; *Haiku* runs mechanical inventory/extraction. Every non-trivial
+decision is logged here and, where exactness matters (licences, invariants,
+equivalence), deferred to formal tooling rather than model judgement.
+
+== Entry 0001 — 2026-07-01 — Kickoff & ground-truth
+
+*Present:* Opus (orchestrator), user (Jonathan).
+
+*Mission (verbatim intent):* ultra-complete the Julia professional registry
+infrastructure and the Julianiser on this run; bring Axiom.jl to utter
+completeness across systems, compliance, effects, and corrective/adaptive/
+perfective maintenance — all claimed and planned features present and correct;
+documentation complete; licensing unambiguous; fully panic-attacked, proven,
+defensible, and coherent within the wider Julia ecosystem, backed by every
+estate capability that can strengthen it. End state: Axiom.jl is the estate's
+Julia flagship and the measuring-stick for all other estate Julia libraries.
+Do this as a demonstration of best-practice agentic design.
+
+*Ground-truth established this session (ran the tools, did not trust docs):*
+
+* All 15 in-scope repos are present on disk under `/home/user`. Nothing missing.
+* *Axiom.jl* — real library, not a scaffold. `Project.toml` name=Axiom,
+  uuid=bbd403f8-…, version=1.0.0, license=MPL-2.0. Subsystems on disk:
+  `types/` `layers/` `autograd/` `training/` `verification/` `dsl/` `backends/`
+  `serving/` `integrations/` `Abi/*.idr` (Idris2 ABI) + `ffi/` + `zig/`.
+  Weakdeps declare CUDA/AMDGPU/Metal/PyCall/SMTLib extensions. Rich `test/ci/`
+  suite (gpu/tpu/npu required-mode, backend parity, certificate integrity,
+  proof-bundle reconciliation, verification telemetry).
+* *julia-professional-registry* — live registry. `Registry.toml`
+  name=JuliaProfessionalRegistry, uuid=2ba92a00-…,
+  repo=github.com/hyperpolymath/HyperpolymathRegistry.git. ~31 packages across
+  A–Z buckets; Axiom is registered (A/Axiom). Has contractiles + CI.
+  NOTE: `Registry.toml` repo URL points at `HyperpolymathRegistry.git`, but the
+  in-scope forge is `hyperpolymath/julia-professional-registry` — possible
+  naming/repo-URL drift to resolve (FLAG, do not assume).
+* *julianiser* — Rust CLI scaffold (auto-wrap Python/R pipelines into Julia).
+  Has `src/{abi,codegen,manifest,...}`, a populated `verification/` tree
+  (proofs/tests/coverage/fuzzing/simulations/safety_case/benchmarks/
+  traceability), and a full `.github/workflows/` set.
+* *Toolchain bare*: julia, z3, cvc5, idris2, agda, lean, coqc, zig, deno, guile,
+  just, gh all ABSENT at session start. Only cargo + git present. Toolchain
+  install kicked off (juliaup LTS 1.10, z3, cvc5, zig).
+
+*Licensing stance fixed up front (from `standards` canon):* Axiom.jl, the
+registry, and julianiser are sole-owner repos ⇒ *MPL-2.0* (code) +
+*CC-BY-SA-4.0* (docs). None are the 007 (ARR), son-shared (AGPL), or
+Palimpsest (PMPL) carve-outs. Therefore licensing work = *verify + complete +
+FLAG drift only*. Absolutely no bulk SPDX sweeps, no relicensing PRs without
+owner approval. New files I author carry correct SPDX from birth (that is
+authoring, not relicensing).
+
+*Development branch (all repos):* `claude/axiom-jl-registry-infra-kr7t4a`.
+
+*Actions taken:*
+. Ground-truth recon of the three core repos + toolchain (done).
+. Background toolchain install started (Julia/z3/cvc5/zig).
+. Launched understand+research workflow: 4 sonnet repo/estate audits +
+  1 haiku mechanical inventory + 2 sonnet web-research agents (agentic-design
+  best practice; Julia-registry & flagship-library best practice), then an
+  opus synthesis into a gap register + phased ultraplan + decision forks.
+
+*Open questions to put to the user (next entry will record answers):* canonical
+home for this diary; how aggressive to be on Axiom "planned" features vs
+"shipped"; registry repo-URL/name drift; whether to gate on real prover runs.
+
+*Next:* synthesise the workflow output into the ULTRAPLAN, present decision
+forks, get sign-off, then execute phase-by-phase on the branch above.
+
+== Entry 0002 — 2026-07-01 — Foundation ground-truth (ran the tool, did not trust the docs)
+
+*Toolchain install: full success.* Julia 1.10.11 (LTS), Z3 4.8.12, cvc5 1.3.4,
+Zig 0.13.0 all on PATH.
+
+*Axiom.jl builds and passes clean under fresh Julia:*
+`Pkg.instantiate()` OK → `Pkg.precompile()` OK (94 deps, ~70s) →
+`using Axiom` OK → *`Pkg.test()` = 642/642 PASS in 1m35s.* The flagship
+foundation is solid, not broken. This is a strong starting point.
+
+*BUT running it surfaced four holes invisible to code-reading — captured now
+so we fix holes-before-features (doctrine #1):*
+
+. *SMT runner test SILENTLY SKIPPED* — log line `Skipping SMT runner test; no
+  solver available` even though z3+cvc5 are installed. Root cause: the
+  `AxiomSMTExt` extension triggers on the `SMTLib` weakdep, which lives in the
+  professional registry; that registry FAILED to add (see #4), so the extension
+  never loaded and the test self-skipped. This is a "no silent green"
+  violation: a claimed capability (SMT-backed verification) is unexercised.
+. *Proofs are EXPORTED but not CHECKED* — the suite emits
+  `softmax_norm.lean`, `.v` (Coq), `.thy` (Isabelle), and a `.proof`
+  certificate, but nothing runs a proof assistant over them. Export ≠ verified.
+  Per "distrust-the-neural-for-exactness", a proof that is only emitted is not
+  a proof. → installing Coq/Agda/Lean/Idris2 now to actually check them.
+. *Backend fallback fires quietly* — `TPU device 4 out of range (available:
+  0:1), falling back to Julia backend`. Need to confirm the GPU/TPU/NPU
+  backends are real vs simulated, and that fallback is loud + certificate-aware.
+. *Professional registry cannot be added as a Julia registry* — cloning it as
+  a registry fails with a git ODB error: `object not found - no match for id
+  (a7be00f811ff2a963b68140d0c30af1dddbe21e7)`. The registry's git state is
+  broken for clone-as-registry (the primary way downstream users would consume
+  it via `Pkg.Registry.add`). CRITICAL registry foundation hole — a registry
+  that can't be added isn't a registry.
+
+*Decision inputs this produces:* (a) SMT + proof-checking must be wired to run
+for real (kills silent-skip); (b) registry git integrity must be repaired and
+verified by an actual `Pkg.Registry.add` round-trip; (c) proof-assistant infra
+is in-scope (installing now). Whether CI hard-gates on real prover execution
+remains a user fork.
+
+*Action:* background-installing Coq, Agda, Lean (elan), Idris2 so the
+proof-verification hole can be closed with real checkers.
+
+*Provers landed:* Coq 8.18.0, Agda 2.6.3, Lean (elan stable) — with Z3/cvc5.
+Idris2 ABSENT (no apt package on Ubuntu noble; source/Chez bootstrap deferred —
+flagged, so Axiom/julianiser Idris2 ABI typecheck becomes CI-only or a scoped
+build task, never a string-match proxy). Isabelle deferred (~1GB+).
+
+== Entry 0003 — 2026-07-01 — Understand workflow landed; ULTRAPLAN drafted
+
+The 8-agent workflow (4 Sonnet audits + 1 Haiku inventory + 2 Sonnet research +
+1 Opus synthesis; ~1.0M tokens, 340 tool calls) returned a ground-truthed
+gap register (41 items), a 9-phase plan (P0–P8), 6 decision forks, estate-wiring
+steps, and risks. Persisted to `ULTRAPLAN.adoc` + `GAP-REGISTER.md` (living
+tracker) in the coordination workspace.
+
+*Headline: Axiom is real and 642/642-green but ships 3 confirmed soundness holes*
+(forgeable cert falsely labelled SHA256-HMAC; `has_safe_operations()==true`
+vacuous NoNaN "proof"; proof-import verifying by regex-absence of `sorry`) plus
+a dead-code/doc knot (`huggingface.jl`). Registry has 2 critical Pkg-resolution
+breakers (repo-URL drift; JuliaKids/JuliaForChildren name↔UUID mismatch) and a
+flag-only PMPL-drift in NOTICE. julianiser has 2 critical codegen bugs +
+unwired ABI/FFI scaffolding.
+
+*Decision to present to owner (4 forks asked, 2 defaulted):* canonical registry
+identity; how far to push planned features; cert relabel-vs-sign; CI real-prover
+gating. Defaults taken (owner may override): diary/ADR home = both per-repo
+`docs/decisions/` + a `standards` index; Julia matrix = 1.10 LTS floor + `1` +
+nightly(non-blocking).
+
+*Method locked in (from the agentic-design research):* holes-first ordering;
+Opus adjudicates every "proven"/"done" via an independent fresh-context
+adversarial pass (assume-false-until-proven, re-run the command, diff exit
+criteria) — no self-grading; pilot the loop on a small slice (Axiom cert-hole +
+registry repo-URL) before fanning out; condensed hand-off reports; disjoint
+worker file-sets; licence files strictly no-touch except birth-authoring.
+
+*Next:* get the 4 fork answers, then execute — P0 finish (build panic-attack) →
+pilot P1/P2 slice → adversarial verify → scale across phases, committing to
+`claude/axiom-jl-registry-infra-kr7t4a` per repo.
+
+== Entry 0004 — 2026-07-01 — Owner forks + the estate trust/crypto ground-truth
+
+*Owner decisions:* registry canonical identity = *JuliaProfessionalRegistry*
+(keep as registry `name`; point `repo` at the real julia-professional-registry
+remote — name≠slug in Julia, so NO GitHub rename needed; sweep ~20 stale
+"HyperpolymathRegistry" mentions, old name → CLADE aliases). Feature scope =
+*push planned features* (coprocessor kernels / ONNX / HuggingFace; hardware
+kernels implementable but only hardware-CI-verifiable — never claimed green from
+this GPU-less box). CI = *hard-gate everything* (real Idris2/SMT/doctest/
+RegistryCI execution; Idris2 local build blocked by proxy 403 → CI-only, retry
+release-tarball). Certificate = discussion (below).
+
+*Builds:* panic-attack built (full CLI). Idris2 local build FAILED (proxy 403 on
+idris-lang git clone; my net scope is hyperpolymath/*) → Idris2 gate is CI-only.
+
+*The crypto/Trustfile discovery (major).* The owner surfaced `proven`'s
+Trustfile as "the estate trust scheme Mistral set out." Ground-truthed:
+* There are TWO senses of "Trustfile" in the estate: (a) the RSR *agent-trust +
+  integrity-invariant* contractile (Axiom already has one: trust-level=standard,
+  no-secrets/no-private-keys invariants, protected semantic-authority surfaces);
+  (b) the *cryptographic* trust spec (proven's rich one).
+* proven's Trustfile is an excellent *spec* but 100% PLACEHOLDERS — declared,
+  not instantiated; every key/hash/sig is `BASE64_...`. "status: proven" is
+  aspirational (ProvenCrypto.jl spec = 0% proof coverage).
+* REAL implementation EXISTS IN SCOPE: `odds-and-sods-package-manager`
+  `opsm_pq_nif` (Rust, `#![forbid(unsafe_code)]`) binds vetted `pqcrypto` crates:
+  Dilithium5 (ML-DSA-87/FIPS204), SPHINCS+-256f-SHAKE (SLH-DSA/FIPS205),
+  Kyber1024 (ML-KEM/FIPS203). Elixir `HybridSignatures` = Ed25519+Dilithium5,
+  both-must-verify, honest fallback modes, e2e-tested.
+* DIVERGENCE: spec says *Ed448*; the only built+tested impl uses *Ed25519*.
+  Per "solutions-at-source" this is the owner's estate-wide reconciliation call.
+* Axiom already declares `integrations/proven.a2ml` (uses proven SafeCrypto,
+  thin-ffi-wrapper). ProvenCrypto.jl is the intended Julia home but 0%-proven +
+  source out-of-scope.
+
+*Design decision (provisional, pending owner):* Axiom's certificate reuses the
+vetted `pqcrypto` crates behind its existing Rust/Zig FFI (no hand-roll, no dep
+on unfinished ProvenCrypto.jl), producing a real Trustfile-conforming hybrid
+signature; cert hashing moves SHA-256 → SHA3-512/SHAKE256/BLAKE3; Kyber1024 KEM
+envelope added (owner approved confidentiality). This makes Axiom the FIRST repo
+to instantiate the estate trust standard for real — the flagship exemplar.
+Open owner forks: classical curve (Ed448 vs Ed25519); crypto provider approach.
+The false `SHA256-HMAC` label is closed immediately regardless.
+
+== Entry 0005 — 2026-07-01 — Pilot slice landed + verified + PR #46
+
+Proceeded on doctrine-consistent crypto defaults (AskUserQuestion tool stream
+dropped; owner said "continue"): classical curve = Ed448 (honor spec; flag
+opsm's Ed25519 as drift); provider = reuse vetted `pqcrypto` crates behind
+Axiom's FFI. Both overridable.
+
+*Pilot executed inline (opus) to prove the loop before fanning out (per risk
+register), on the scheme-INDEPENDENT holes:*
+* G02 (checker.jl) — `has_safe_operations()` bare `true` removed; NoNaN no longer
+  vacuously `:proven`, routes to empirical. FIXED + verified.
+* G01 relabel (certificates.jl) — false `"SHA256-HMAC"` label over an unkeyed
+  digest removed; now honest `algorithm=SHA-256, kind=content-digest,
+  authenticated=false` + note. Docstrings corrected. Hybrid Ed448+Dilithium5
+  authenticating signature = tracked follow-up. RELABEL done + verified.
+* Added `test/verification/soundness_tests.jl` to the main suite (guards both).
+
+*Ground-truthed verification (ran the tools, no self-grade):* `Pkg.test()` =
+*651/651 pass* (642 + 9 new); `test/ci/certificate_integrity.jl` = *6/6 pass*.
+
+*Committed* bdb9244 to `claude/axiom-jl-registry-infra-kr7t4a`; pushed; opened
+*draft PR hyperpolymath/Axiom.jl#46*. Subscribed to PR activity (watch CI +
+reviews to merge/close).
+
+*Loop proven.* Next: scale to the remaining Axiom P1 holes (G03 proof-import
+theorem-presence; G04 @prove relabel; G05 Idris2 ABI↔zig) and the registry P2
+criticals (G20 repo-URL, G21 JuliaKids↔JuliaForChildren) — now safe to fan out
+sonnet workers on disjoint files with opus adversarial verify. The big hybrid-
+signing (G01 auth) is its own Rust/FFI chunk.
+
+== Entry 0006 — 2026-07-01 — Parallel fan-out wave merged; follow-up on fresh main
+
+*Orchestration demonstration ran:* three parallel Sonnet workers (one per repo,
+disjoint working trees), each closing that repo's critical holes with real-tool
+verification, then *Opus adversarially re-verified every result independently*
+(re-ran Pkg.test / cargo test / zig build from clean, reviewed git diffs, checked
+no licence files touched) BEFORE any commit. All three passed and were pushed as
+draft PRs.
+
+*Owner merged all three* (squash): Axiom #46 (pilot G01-relabel + G02), registry
+#40 (G20 repo-URL, G21 JuliaKids→JuliaForChildren), julianiser #48
+(G30 bracket-depth, G31 scope-model, G32 FFI honest-relabel, G33 Zig-0.13 build).
+Branches auto-deleted on squash.
+
+*Axiom worker also delivered G03/G04/G05* (proof-import theorem-presence check;
+@prove honest relabel; Idris2-ABI illustrative-scaffold labelling + flagged the
+orphan ffi/zig tree with zero axiom_* exports as a KNOWN ISSUE). Verified
+670/670. Because #46 was squash-merged, the branch was RESTARTED from fresh main
+and only the G03/G04/G05 commit replayed (no stacking on merged history), plus
+this diary + ULTRAPLAN promoted into docs/design-diary/ for the online record.
+A NEW PR carries this follow-up.
+
+*Gap status (verified/fixed):* G01(relabel), G02, G03, G04, G20, G21, G30, G31,
+G32, G33. G05 = honest relabel done; full ABI↔zig connection deferred (Idris2
+CI-only). Registry Pkg-add round-trip = CI-only (sandbox libgit2 quirk).
+
+*Method held:* holes-first; ran the tools not the docs; no self-grade (opus
+independent verify); no licence edits; birth-SPDX on new files; pushed + PR'd
+each repo so nothing lives only on local disk.

--- a/docs/design-diary/ULTRAPLAN.adoc
+++ b/docs/design-diary/ULTRAPLAN.adoc
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
+= ULTRAPLAN — Axiom.jl Estate Julia Flagship Initiative
+Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+:toc: left
+:sectnums:
+:revdate: 2026-07-01
+
+Produced by an 8-agent understand+research workflow (4 Sonnet deep audits, 1
+Haiku mechanical inventory, 2 Sonnet web-research agents, 1 Opus synthesis;
+~1.0M tokens, 340 tool calls). Every finding below was verified by reading the
+actual code/greps, not by trusting status docs. Branch for all work:
+`claude/axiom-jl-registry-infra-kr7t4a`.
+
+== Executive summary (ground-truthed)
+
+*Axiom.jl* is a substantial, genuinely-tested Julia ML framework — 97 `.jl`
+files, 642 passing tests, a 3-OS × Julia 1.10/1.11 CI matrix, a real Zig
+backend with 36 exported kernels, strong invertible-layer round-trip tests.
+It is **not** flagship-ready: it ships **three confirmed soundness holes** plus
+a high-severity dead-code/doc-drift knot.
+
+* *Forgeable "signed" certificate* — `certificates.jl` hashes public fields with
+  a bare, unkeyed `SHA.sha256`, then labels the output `"SHA256-HMAC"` and
+  markets it for `fda_submission.cert`. Anyone can forge it.
+* *Vacuous NoNaN proof* — `checker.jl::has_safe_operations()` is a bare `true`,
+  so every NoNaN request on the static path is "proven safe" regardless of
+  div/log ops.
+* *Fake proof verification* — Lean/Coq/Isabelle "verification" is regex-absence
+  of `sorry`/`Admitted`; an empty file "passes". `@prove` is `contains(string(expr),"relu")`
+  substring matching, docstring'd as "symbolic execution / formal verification".
+* *Dead-code/doc knot* — `huggingface.jl` (825 lines) is not in the include
+  chain; `JSON3` is a hard dep serving only it; `TOPOLOGY` says "Done 80%",
+  `REGISTRY-READINESS` says "removed" — both false.
+
+*julia-professional-registry* (37 packages, correct wire format) has **two
+critical Pkg-resolution breakers**: (1) `Registry.toml` `repo` points at a stale
+`HyperpolymathRegistry.git` while the real remote is `julia-professional-registry`,
+and the `name` is a *third* variant; (2) `H/Hyperpolymath/Deps.toml` calls UUID
+`c1c96f90-…` "JuliaKids" while `Registry.toml` binds it to "JuliaForChildren" —
+`Pkg.add Hyperpolymath` breaks. No RegistryCI/AutoMerge/TagBot/CompatHelper. The
+`NOTICE` falsely claims PMPL-1.0 (flag-only — owner-manual).
+
+*julianiser* is a working Rust CLI (33/33 tests, clean clippy) with **two
+critical codegen bugs** (no bracket-depth tracking → emits unparseable
+`collect([1)`; local-var/library-alias conflation → generated "drop-in" modules
+throw `error()` on first DataFrame call) and an entire Idris2-ABI + Zig-FFI layer
+that is unwired dead scaffolding (the Rust binary never `dlopen`s it) — a
+"wire-first" violation. The three repos cross-reference each other **zero** times
+despite julianiser existing to emit registrable Julia.
+
+*Shape of the work:* holes first → reconcile docs to reality → panic-attack all
+three + audited suppressions → wire estate tooling (Aqua/JET/Documenter/
+RegistryCI/k9/squabble/RSR gates) → formalise the flagship measuring-stick rubric.
+
+== Orchestration model (the agentic-design demonstration)
+
+* *Opus (me)* — decompose, synthesise, and **adjudicate every "proven"/"done"
+  claim** via an independent fresh-context adversarial verify pass
+  ("assume false until proven", re-run the stated command, diff vs exit
+  criteria). No self-grading.
+* *Sonnet* — per-repo audits, builds, fixes, tests.
+* *Haiku* — mechanical sweeps (marker inventory, birth-SPDX headers, name-drift
+  find/replace under Sonnet review).
+* Durable external memory: this ULTRAPLAN + `GAP-REGISTER.md` + the Pepys diary,
+  surviving context resets. Condensed 1–2k-token hand-off reports, not raw dumps.
+
+== Gap register (33 confirmed, by repo)
+
+See `GAP-REGISTER.md` for the machine-readable form. Severity ∈
+{critical,high,medium,low}; kind ∈ {system,compliance,effect,corrective,adaptive,perfective}.
+
+=== Axiom.jl
+. *[critical/system]* Forgeable cert falsely labelled SHA256-HMAC → relabel `tamper_evidence_hash` + strip marketing (or real Ed25519); forgery test rejects.
+. *[critical/system]* `has_safe_operations()==true` vacuous NoNaN → remove from `:proven`; unsafe-op model must not be `:proven`.
+. *[high/system]* Proof-import "verify" = regex-absence → require ≥1 theorem + no admit; empty file → `:incomplete`.
+. *[high/compliance]* `@prove` substring match mislabelled formal → relabel experimental heuristic, default `:unknown`.
+. *[high/system]* Idris2 ABI declares generic FFI ≠ 36 real zig exports → connect to real exports OR relabel illustrative; kill orphan `ffi/zig/`.
+. *[high/perfective]* `huggingface.jl` dead + `JSON3` hard dep only for it; docs contradict → wire+test OR delete + drop JSON3; fix docs.
+. *[medium/adaptive]* No Aqua/JET (readiness doc claims Aqua "passed") → add both + CI jobs.
+. *[medium/corrective]* Weakdeps lack `[compat]`; Zygote pinned 0.6; KernelAbstractions orphan weakdep → bound all, fix.
+. *[medium/system]* `SMTLib` weakdep resolves only in-monorepo → register SMTLib.jl OR document monorepo-only (this is why the SMT test silently skipped).
+. *[medium/perfective]* Root LLM-tell files present despite "Removed"; dangling README.adoc ref → remove or correct.
+. *[medium/perfective]* EXPLAINME calls AcceleratorGate a hard dep though vendored → correct.
+. *[medium/compliance]* README coprocessor section overclaims (kernels are skeleton) → add qualifier.
+. *[medium/adaptive]* No `docs/make.jl` Documenter/doctests → add + Documentation CI.
+. *[medium/adaptive]* No `static-analysis-gate.yml`; Justfile `assail` points at pre-rename `panic-attacker` → add gate + fix name.
+. *[medium/adaptive]* No project `k9iser.toml` → author (safety-tier=fv).
+. *[medium/adaptive]* Missing RSR required files → copy from template + validate.
+. *[low/compliance]* Some `.idr`/`.zig` lack SPDX → birth-author MPL-2.0 headers (no sweep).
+. *[low/compliance]* No `audits/assail-classifications.a2ml` → author after first assail (audited residuals only).
+. *[low/perfective]* proven-tests taxonomy not applied (AGPL repo → no code dep) → adopt as doc convention.
+
+=== julia-professional-registry
+[start=20]
+. *[critical/system]* `Registry.toml repo` ≠ git remote → fix URL + CI equality check.
+. *[critical/system]* Hyperpolymath `Deps/Compat.toml` JuliaKids vs Registry JuliaForChildren → rename + CI name↔UUID cross-validation (all 37).
+. *[high/perfective]* Third name variant; ~20 stale-name files → rename sweep (canonical fork FIRST) + CLADE aliases.
+. *[high/system]* No RegistryCI/AutoMerge/TagBot/CompatHelper; only test is Idris2 string-match (asserts a nonexistent README.adoc) → add RegistryCI.
+. *[high/compliance]* `NOTICE` falsely claims PMPL-1.0 → **FLAG-ONLY to owner** (no auto-edit).
+. *[medium/adaptive]* No semver/AutoMerge guideline; compat lower-bounds only → write policy + enforce.
+. *[medium/perfective]* Doc-map drift (claims README.adoc/deno.json/flake.nix; STATE 0% vs shipped v1.0.0) → reconcile.
+. *[medium/perfective]* No julianiser↔registry integration docs → document the pipeline.
+. *[low/corrective]* stapeln/guix copy-paste; copilot `npx` (self-banned); duplicate `secrets:inherit`; malformed curl → fix/exempt.
+. *[low/perfective]* GOVERNANCE references `docs/decisions/` that doesn't exist → create ADR dir.
+
+=== julianiser
+[start=30]
+. *[critical/system]* `extract_parenthesised_args` tracks only `()` → unparseable `collect([1)` → track `[]`/`{}`/strings + parse test.
+. *[critical/system]* No scope model; local `var.method()` → `error("Unmapped call")` → gate on import-alias table + test.
+. *[critical/system]* Zig FFI stubs; Rust never dlopens; whole ABI/FFI dead → wire OR relabel (no overclaim).
+. *[high/corrective]* `build.zig` fails on Zig 0.13 (`addInstallHeader` gone; missing header/bench); CI hides it via `zig test` → fix + `zig build test`.
+. *[high/compliance]* `.idr` never typechecked in CI (regex only) → add `idris2 --build` job.
+. *[high/system]* R `%>%` multi-line pipes mis-parsed; README claims "via AST" → multi-line join + relabel "line-based scan".
+. *[high/adaptive]* `verification/` + `src/{core,aspects,bridges,contracts,definitions,errors}/` 100% empty scaffolding → populate minimal fuzz/coverage OR remove + fix STATE.
+. *[medium/corrective]* Containerfile/guix.scm/THREAT-MODEL unrendered `{{PLACEHOLDER}}` → render or remove.
+. *[medium/perfective]* README claims sklearn→MLJ/broadcasting with no mappings → implement or mark planned.
+. *[medium/compliance]* README `cargo install julianiser` fails (unpublished); some `.rs`/`.zig` lack SPDX → mark planned/publish + birth SPDX.
+
+=== estate
+[start=40]
+. *[medium/adaptive]* No `standards/julia-ci-reusable.yml` → author; Axiom CI wraps it by SHA.
+. *[low/adaptive]* squabble v0.1 diagnose-only → add `just squabble-diagnose` (diagnostic only; no apply plumbing exists upstream).
+
+== Phased plan (holes first)
+
+* *P0 — Toolchain verification & ground-truth harness.* DONE this session:
+  Julia 1.10.11 LTS, Z3 4.8.12, cvc5 1.3.4, Zig 0.13.0, Coq 8.18, Agda 2.6.3,
+  Lean(elan) installed; Idris2 absent (flagged, CI-only or source build). Axiom
+  instantiates + 642/642 tests pass. Remaining: build panic-attack; stand up
+  durable gap-register files; define hand-off schema.
+* *P1 — Axiom soundness-hole closure.* Cert, has_safe_operations, proof-import,
+  @prove relabel, Idris2 ABI. Exit: no false SHA256-HMAC; forged-cert rejected;
+  unsafe-op not `:proven`; empty proof `:incomplete`; no "symbolic execution"
+  claim for `@prove`; ABI symbols match zig OR marked illustrative; full suite green.
+* *P2 — Registry resolution-breaker closure.* Canonical identity (fork) → repo
+  URL + name↔UUID fix + rename sweep. Exit: `repo == git remote`; name↔UUID
+  cross-check passes; CI `Pkg.Registry.add + Pkg.add Hyperpolymath` green.
+* *P3 — julianiser codegen-hole closure.* Bracket depth, scope model, R pipes,
+  FFI wire-or-relabel, `zig build test`, idris2 build job. Exit: generated `.jl`
+  parses + no `error("Unmapped call")` for local chains; `zig build test` green;
+  no "via AST"/working-FFI claim unless true.
+* *P4 — Doc/claim reconciliation.* Every honesty doc consistent with the tree.
+* *P5 — panic-attack integration & audited suppression.* Assail all three;
+  triage into register; author only audited `assail-classifications.a2ml`; wire
+  `static-analysis-gate.yml`. Exit: zero unaudited critical/high; gate in CI.
+* *P6 — Estate tooling wiring.* Aqua/JET/Documenter/RegistryCI/k9/squabble/RSR +
+  `standards/julia-ci-reusable.yml` + feedback-o-tron loop. Unwired ≠ done.
+* *P7 — Licensing verification (FLAG-ONLY).* Confirm MPL-2.0/CC-BY-SA-4.0;
+  FLAG the NOTICE PMPL drift; birth-SPDX on new files only; no header sweeps.
+* *P8 — Flagship measuring-stick rubric.* Machine-checkable rubric in `standards`;
+  grade Axiom as the exemplar; Opus adversarial verify of any "meets rubric".
+
+Pilot before fan-out (risk mitigation): run the orchestrator→worker→verify→
+gap-register loop on a small slice first (Axiom P1 cert-hole + registry P2
+repo-URL), shake out the hand-off schema and scope boundaries, then scale.
+
+== Decision forks (see chat — 4 asked; 2 defaulted)
+
+. Registry canonical identity → *recommend `julia-professional-registry`*.
+. Planned-features scope → *recommend Middle (holes+honesty+tooling; settle HuggingFace; coprocessor/ONNX labelled skeleton)*.
+. Certificate signing → *recommend relabel now + schedule Ed25519 follow-up*.
+. CI real-prover gating → *recommend Hybrid (real required checks scoped to where tools exist; ban string-match proxies)*.
+. Diary/ADR home → *default: BOTH per-repo `docs/decisions/` + `standards` index*.
+. Julia matrix → *default: 1.10 LTS floor + `1` stable + nightly(non-blocking); `[compat] julia = "1.10"`*.
+
+== Key risks
+
+* Self-graded "done"/"proven" is the top failure mode → mandatory independent
+  adversarial verify pass per claim.
+* Idris2/some tools absent locally → mark those exit criteria CI-only; forbid
+  string-match proxies from counting as verification.
+* Licence tripwire (neurophone#99 precedent) → NOTICE PMPL drift stays
+  flag-only; scope every diff to exclude LICENSES/, NOTICE, SPDX-only lines
+  except birth-authoring on new files.
+* Registry fixes are outward-facing (real Pkg resolution) → stop-first on the
+  identity fork; verify `Pkg.add` end-to-end in CI before claiming resolved.
+* Concurrent-worker file conflicts → disjoint file-sets + explicit no-touch boundaries.
+* Scope creep into planned features → enforce holes-first ordering.
+* Honesty-doc drift recurrence → P4 is a gated exit criterion + a rubric check.

--- a/docs/wiki/Verification.md
+++ b/docs/wiki/Verification.md
@@ -7,15 +7,22 @@
 
 ## Overview
 
-Axiom.jl's verification system lets you **prove properties** about your models. This isn't just testing - it's mathematical certainty.
+Axiom.jl's verification system lets you check properties about your models
+at several levels of rigor. `@ensure` is a runtime assertion. `@prove`
+*attempts* to establish a property via, in order: an experimental heuristic
+substring match, an optional real SMT solver (only when `SMTLib.jl` is
+loaded), and a second experimental heuristic pattern match -- falling back
+to `:unknown` when none of these can decide the property. Only the SMT path
+(and the Lean/Coq/Isabelle export/import workflow) produces an actual
+formal-methods result; the two heuristic paths are convenience shortcuts for
+a fixed list of well-known properties, not proofs.
 
 ```julia
 @axiom Classifier begin
     # ...
 
-    # These aren't just assertions - they're GUARANTEES
     @ensure sum(output) ≈ 1.0      # Runtime check
-    @prove ∀x. output(x) ∈ [0, 1]  # Mathematical proof
+    @prove ∀x. output(x) ∈ [0, 1]  # Experimental proof attempt (see caveats below)
 end
 ```
 
@@ -27,7 +34,7 @@ end
                     ╱╲
                    ╱  ╲
                   ╱    ╲
-                 ╱ @prove╲        <- Mathematical proofs
+                 ╱ @prove╲        <- Experimental proof attempt (heuristic + optional SMT)
                 ╱________╲
                ╱          ╲
               ╱  @ensure   ╲     <- Runtime assertions
@@ -114,17 +121,21 @@ end
 
 ---
 
-## @prove: Formal Proofs
+## @prove: Experimental Proof Attempts
 
 ### What Can Be Proven?
 
-The `@prove` macro attempts to **mathematically prove** properties about your model.
+The `@prove` macro *attempts* to establish properties about your model. It
+is **experimental** and is honest about being inconclusive: unless the SMT
+path fires, `@prove` is doing textual pattern matching, not proving anything
+in the formal-methods sense. Treat a `:proven` result from the heuristic
+paths as "recognized, not derived" -- always pair `@prove` with `@ensure`
+for anything safety-relevant.
 
 ```julia
 @axiom Model begin
     # ...
 
-    # These are PROVEN, not just tested
     @prove ∀x. sum(softmax(x)) == 1.0
     @prove ∀x. all(sigmoid(x) .∈ [0, 1])
     @prove ∀x. relu(x) >= 0
@@ -133,10 +144,27 @@ end
 
 ### How It Works
 
-1. **Pattern Matching**: Known properties of functions (e.g., softmax always sums to 1)
-2. **Symbolic Execution**: Trace computation symbolically
-3. **SMT Solvers**: Use Z3/CVC5 for complex properties
-4. **Fallback**: If unprovable, becomes runtime assertion
+`prove_property` tries three strategies in order and stops at the first
+that returns a decided (non-`:unknown`) result:
+
+1. **`symbolic_prove` (experimental heuristic, NOT symbolic execution)**:
+   stringifies the property body and does a literal substring check for the
+   tokens `"true"`/`"false"`. It does not trace, interpret, or simplify the
+   computation.
+2. **SMT solving (real, sound within solver limits)**: only runs if
+   `SMTLib.jl` is loaded (`using SMTLib`) and the property passes a
+   syntactic compatibility check. This is the only strategy that performs
+   genuine automated theorem proving (Z3/CVC5/etc. via `packages/SMTLib.jl`).
+3. **`heuristic_prove` (experimental heuristic, NOT a theorem prover)**:
+   matches known textual patterns in the stringified AST against a fixed
+   list of common neural-network properties (softmax sums to 1, ReLU
+   non-negative, sigmoid/tanh bounds, and similar). A match reports
+   `:proven` by convention, not by derivation.
+4. **Fallback**: if none of the above decide the property, `@prove` returns
+   `:unknown` -- this is the expected, honest outcome for anything outside
+   the recognized patterns and outside SMT's reach. Wrap such properties in
+   `@ensure` for a runtime check, or use the Lean/Coq/Isabelle export path
+   (`proof_export.jl`) for an actual interactive formal proof.
 
 ### SMT Solver Configuration
 

--- a/src/Abi/Foreign.idr
+++ b/src/Abi/Foreign.idr
@@ -1,6 +1,21 @@
 -- SPDX-License-Identifier: MPL-2.0
 ||| Axiom.jl Foreign Function Interface Declarations
 |||
+||| ILLUSTRATIVE SCAFFOLD -- NOT A PROOF OF AXIOM'S PRODUCTION FFI BOUNDARY.
+||| The symbols declared here (axiom_init, axiom_process, axiom_free,
+||| axiom_register_callback, axiom_invoke_callback, etc.) are a generic
+||| lifecycle/callback surface for the hyperpolymath ABI-FFI pattern. They
+||| use concrete Axiom naming but do NOT correspond to Axiom's real Zig
+||| kernel exports (axiom_matmul, axiom_relu, axiom_conv2d, and the rest of
+||| the ~36 real exports in `ffi/zig/src/main.zig` / `zig/src/axiom.zig`
+||| consumed by `src/backends/zig_ffi.jl`). No `libaxiom` implementing
+||| exactly this surface is built by this repository.
+|||
+||| The production FFI boundary is Julia <-> Zig via `src/backends/zig_ffi.jl`
+||| and `ffi/zig/`; see `ABI-FFI-README.md` for the authoritative split.
+||| Connecting this scaffold's declarations to the real Zig exports is
+||| tracked future work (see ROADMAP note in `src/Abi/Types.idr`).
+|||
 ||| This module declares C ABI symbols used by the Idris2 ABI scaffold.
 ||| Symbol names are concrete for Axiom (`axiom_*`, `libaxiom`).
 

--- a/src/Abi/Layout.idr
+++ b/src/Abi/Layout.idr
@@ -1,6 +1,19 @@
 -- SPDX-License-Identifier: MPL-2.0
 ||| Axiom.jl ABI Layout Utilities
 |||
+||| ILLUSTRATIVE SCAFFOLD -- NOT A PROOF OF AXIOM'S PRODUCTION FFI BOUNDARY.
+||| This is a generic struct-layout model (example fields, example struct)
+||| for the hyperpolymath ABI-FFI pattern; it does not describe the layout
+||| of any real Axiom/Zig data structure. `checkCABI` always returns
+||| `Right CABIProof` regardless of input -- it is not a real compliance
+||| check. See `src/Abi/Types.idr` for the full scaffold-vs-production
+||| explanation and `ABI-FFI-README.md` for the authoritative FFI split
+||| (production boundary: `zig/` + `src/backends/zig_ffi.jl`).
+|||
+||| ROADMAP: replace `checkCABI`'s trivial `Right` with a real layout
+||| compatibility check against the actual struct layouts crossing the
+||| Zig FFI boundary (tracked future work; see Types.idr ROADMAP note).
+|||
 ||| This module provides a lightweight, concrete memory-layout model used by
 ||| the Idris2 ABI scaffold.
 

--- a/src/Abi/Types.idr
+++ b/src/Abi/Types.idr
@@ -1,6 +1,26 @@
 -- SPDX-License-Identifier: MPL-2.0
 ||| Axiom.jl ABI Type Definitions
 |||
+||| ILLUSTRATIVE SCAFFOLD -- NOT A PROOF OF AXIOM'S PRODUCTION FFI BOUNDARY.
+||| This module defines a generic `axiom_*`/`libaxiom` ABI surface
+||| (axiom_init/axiom_process/axiom_register_callback, etc.) that does NOT
+||| match the ~36 real Zig exports (axiom_matmul, axiom_relu, axiom_conv2d,
+||| and friends) actually used by `src/backends/zig_ffi.jl`. It is a
+||| worked example of the hyperpolymath ABI-FFI pattern (Idris2 ABI + Zig
+||| FFI), not a formal specification of Axiom's shipped kernels.
+|||
+||| The production FFI boundary lives in `zig/` (kernel implementations)
+||| and `src/backends/zig_ffi.jl` (Julia-side ccall wiring); see
+||| `ABI-FFI-README.md` for the authoritative split. Connecting this .idr
+||| surface to the real Zig exports is tracked future work (ROADMAP note
+||| below); until then, treat `Verify.verifySizes` / `Verify.verifyAlignments`
+||| in this file as `putStrLn` placeholders, not executed proofs.
+|||
+||| ROADMAP: extend this scaffold (and Layout.idr/Foreign.idr) with typed
+||| declarations for each real `axiom_*` Zig export and replace the
+||| `Verify` namespace stubs with actual size/alignment/signature proofs
+||| checked against `zig/src/axiom.zig` and `ffi/zig/include/axiom.h`.
+|||
 ||| This module defines the core ABI-facing types used by the Idris2
 ||| specification layer for Axiom.jl.
 

--- a/src/dsl/prove.jl
+++ b/src/dsl/prove.jl
@@ -4,9 +4,35 @@
 """
     @prove [quantifier] property
 
-The `@prove` macro is used to formally verify properties of Julia expressions.
-It attempts to prove or disprove a given property using a combination of
-symbolic execution, SMT solving, and other formal methods.
+The `@prove` macro attempts to prove or disprove a property of a Julia
+expression by dispatching, in order, to up to three strategies:
+
+1. `symbolic_prove`: an **experimental heuristic**, not symbolic execution.
+   It stringifies the property's AST and does a literal substring match for
+   `"true"`/`"false"` tokens. It does not interpret, simplify, or evaluate
+   the expression in any principled way.
+2. **SMT solving** (real, sound within solver limits): only runs when
+   `SMTLib.jl` is loaded (`using SMTLib`) and the `AxiomSMTExt` extension is
+   active. This is the only strategy in `@prove` that performs genuine
+   automated theorem proving.
+3. `heuristic_prove`: another **experimental heuristic**, not a theorem
+   prover. It matches known textual patterns (e.g. `contains(string(expr),
+   "relu")`) against the stringified AST to recognize a fixed list of common
+   neural-network properties (softmax sums to 1, ReLU is non-negative,
+   etc.) and reports them `:proven` by convention, not by proof.
+
+If none of these strategies can decide the property, `@prove` returns
+`ProofResult(:unknown, ...)` -- this is the honest default for anything the
+heuristics don't recognize and SMT is unavailable or inconclusive for.
+
+**Strategies 1 and 3 are NOT symbolic execution and NOT formal verification.**
+They are literal substring matches on `string(expr)`. A `:proven` result from
+either heuristic path means "this expression's printed form matched a known
+textual pattern", not "this property was formally proved". For an actual
+formal-methods result, load `SMTLib.jl` (strategy 2) or export the property
+to Lean/Coq/Isabelle via `proof_export.jl` and complete the proof
+interactively -- see `docs/wiki/Verification.md` and
+`docs/wiki/AdvancedSMT.md`.
 
 ## Arguments:
 - `quantifier`: Optional. Specifies the quantifier for the property.
@@ -215,7 +241,8 @@ end
 Dispatches to the appropriate proving strategy based on the property.
 """
 function prove_property(property::ParsedProperty)::ProofResult
-    # Strategy 1: Symbolic execution with simplification
+    # Strategy 1: Experimental heuristic -- literal substring match on the
+    # stringified AST. NOT symbolic execution (see symbolic_prove docstring).
     result = symbolic_prove(property)
     result.status != :unknown && return result
 
@@ -228,7 +255,8 @@ function prove_property(property::ParsedProperty)::ProofResult
         end
     end
 
-    # Strategy 3: Heuristic-based pattern matching for common properties
+    # Strategy 3: Experimental heuristic -- pattern matching for common
+    # properties. NOT a theorem prover (see heuristic_prove docstring).
     result = heuristic_prove(property)
     result.status != :unknown && return result
 
@@ -243,40 +271,62 @@ end
 """
     symbolic_prove(property::ParsedProperty)
 
-Attempts to prove a property using symbolic execution and simplification.
+**Experimental heuristic. Not symbolic execution, not a theorem prover.**
+
+Converts `property.body` to its printed string form via `string(...)` and
+does a literal substring check for the tokens `"true"` / `"false"`. It
+performs no AST interpretation, term rewriting, or simplification -- the
+name "symbolic" refers only to inspecting the unevaluated expression's
+printed text, not to symbolic execution in the program-analysis sense.
+
+Returns `:unknown` (via `ProofResult`) whenever the substring check is
+inconclusive, which is the common case; real proving for anything beyond
+this trivial pattern belongs to the SMT extension (`AxiomSMTExt`, strategy 2
+in `prove_property`) or the Lean/Coq/Isabelle export path in
+`proof_export.jl`.
 """
 function symbolic_prove(property::ParsedProperty)::ProofResult
-    # Lightweight symbolic pass:
-    # 1. Represent the property body symbolically.
-    # 2. Apply simplification rules.
-    # 3. Attempt to reduce the expression to `true` or `false`.
-    # 4. If false, try to extract a counterexample.
-
-    # For now, a very basic symbolic check:
+    # Experimental heuristic pass, NOT symbolic execution:
+    # literal substring match on `string(property.body)` for the tokens
+    # "true"/"false". No AST interpretation, term rewriting, or
+    # simplification is performed.
     body_str = string(property.body)
     if property.quantifier == :forall
         if contains(body_str, "true") && !contains(body_str, "false")
-            return ProofResult(:proven, nothing, 0.5, "Property trivially true (symbolic).", String[])
+            return ProofResult(:proven, nothing, 0.5, "Property trivially true (heuristic substring match; not symbolic execution).", String[])
         elseif contains(body_str, "false") && !contains(body_str, "true")
-            return ProofResult(:disproven, Dict(), 0.5, "Property trivially false (symbolic).", String[])
+            return ProofResult(:disproven, Dict(), 0.5, "Property trivially false (heuristic substring match; not symbolic execution).", String[])
         end
     elseif property.quantifier == :exists
         if contains(body_str, "true") && !contains(body_str, "false")
-            return ProofResult(:proven, Dict(), 0.5, "Property trivially true (symbolic).", String[])
+            return ProofResult(:proven, Dict(), 0.5, "Property trivially true (heuristic substring match; not symbolic execution).", String[])
         elseif contains(body_str, "false") && !contains(body_str, "true")
-            return ProofResult(:disproven, nothing, 0.5, "Property trivially false (symbolic).", String[])
+            return ProofResult(:disproven, nothing, 0.5, "Property trivially false (heuristic substring match; not symbolic execution).", String[])
         end
     end
 
     return ProofResult(:unknown, nothing, 0.0,
-                       "Symbolic execution could not determine truth value.",
+                       "Heuristic substring match could not determine a truth value (this is not symbolic execution).",
                        String[])
 end
 
 """
     heuristic_prove(property::ParsedProperty)
 
-Applies heuristic pattern matching to common properties.
+**Experimental heuristic. Not a theorem prover, not formal verification.**
+
+Applies textual pattern matching (e.g. `contains(string(expr), "relu")`)
+against the stringified AST of `property.body` to recognize a fixed list of
+common neural-network properties (softmax sums to 1, ReLU is non-negative,
+sigmoid/tanh bounds, etc.). A `:proven` result here means the printed
+expression matched one of these known text patterns -- it is not the output
+of a proof search, term rewriter, or solver, and it carries no soundness
+guarantee beyond "this looks like a property we've seen before".
+
+Returns `:unknown` for anything that doesn't match a recognized pattern.
+Real automated proving is handled by the SMT extension (`AxiomSMTExt`) when
+`SMTLib.jl` is loaded; interactive formal proofs go through the
+Lean/Coq/Isabelle export path in `proof_export.jl`.
 """
 function heuristic_prove(property::ParsedProperty)::ProofResult
     # Heuristic 1: Check for basic tautologies/contradictions

--- a/src/proof_export.jl
+++ b/src/proof_export.jl
@@ -193,11 +193,62 @@ function _assistant_placeholder_regex(assistant::Symbol)
     throw(ArgumentError("Unsupported proof assistant: $assistant"))
 end
 
+# Matches a theorem/lemma *declaration* header for the given assistant
+# syntax, capturing the declared name and the claimed statement text (up to
+# the point where the proof body begins) so:
+#  (a) boilerplate (the AXIOM_CERTIFICATE_HASH witness emitted into every
+#      exported file) can be told apart from an actual claimed-property
+#      statement, and
+#  (b) a vacuous claim (bare `True` / `"True"`, proving nothing about the
+#      model) can be told apart from a real property statement.
+function _assistant_statement_regex(assistant::Symbol)
+    if assistant == :lean
+        # `theorem NAME : STATEMENT := by|:= ...`
+        return r"\btheorem\s+(\w+)[^\n:]*:\s*(.*?)\s*:="
+    elseif assistant == :coq
+        # `Theorem NAME : STATEMENT.` (statement ends at the line's period)
+        return r"\bTheorem\s+(\w+)\s*:\s*(.*?)\.\s*(?:\r?\n|$)"
+    elseif assistant == :isabelle
+        # `theorem NAME: "STATEMENT"` or `lemma NAME: "STATEMENT"`
+        return r"\b(?:theorem|lemma)\s+(\w+)\s*:\s*\"+(.*?)\"+"
+    end
+    throw(ArgumentError("Unsupported proof assistant: $assistant"))
+end
+
+# A claim consisting only of the literal `True` (Lean/Coq) proves nothing
+# about the model -- it is the same vacuous placeholder emitted by the
+# fallback branches in `export_lean/coq/isabelle(model, properties)`.
+function _vacuous_statement(statement::AbstractString)
+    s = strip(statement)
+    isempty(s) && return true
+    lowercase(s) == "true"
+end
+
+# A proof is only credible evidence of a claimed property if it contains at
+# least one theorem/lemma that is (a) not the fixed `axiom_certificate_witness`
+# metadata boilerplate emitted into every exported file regardless of whether
+# the real property was ever addressed, and (b) not a vacuous `True`-only
+# tautology. An empty file, a file that only restates the certificate-hash
+# witness, or a file with a `theorem foo : True := trivial`-style placeholder
+# must not be treated as containing a real proof obligation.
+function _assistant_has_substantive_statement(content::String, assistant::Symbol)
+    for m in eachmatch(_assistant_statement_regex(assistant), content)
+        name = m.captures[1]
+        statement = m.captures[2]
+        name == "axiom_certificate_witness" && continue
+        _vacuous_statement(statement) && continue
+        return true
+    end
+    return false
+end
+
 function _assistant_obligation_summary(content::String, assistant::Symbol)
     unresolved = count(_ -> true, eachmatch(_assistant_placeholder_regex(assistant), content))
+    has_statement = _assistant_has_substantive_statement(content, assistant)
     (
         unresolved = unresolved,
-        complete = unresolved == 0
+        has_statement = has_statement,
+        complete = unresolved == 0 && has_statement
     )
 end
 
@@ -228,6 +279,10 @@ function _assistant_status_label(
     if !hash_matches || !obligation_matches
         return "metadata_mismatch"
     end
+    # `summary.complete` already folds in `has_statement`: a file with zero
+    # escape tokens (no sorry/Admitted/oops) but also zero substantive
+    # theorem/lemma statements is NOT "complete" -- it is a vacuous or empty
+    # proof and must be reported "incomplete" rather than falsely verified.
     summary.complete ? "complete" : "incomplete"
 end
 
@@ -271,6 +326,7 @@ function proof_assistant_obligation_report(
         "path" => path,
         "status" => status,
         "unresolved" => summary.unresolved,
+        "has_statement" => summary.has_statement,
         "complete" => status == "complete",
         "certificate_hash" => markers.certificate_hash,
         "obligation_id" => markers.obligation_id,
@@ -890,7 +946,9 @@ end
 """
     import_lean_certificate(lean_file::String; expected_certificate_hash=nothing, expected_obligation_id=nothing) -> ProofCertificate
 
-Import a completed Lean proof file and check for sorry-free status.
+Import a completed Lean proof file and check that it is sorry-free AND
+contains an actual property theorem (not just the certificate-hash witness
+boilerplate or an empty file).
 """
 function import_lean_certificate(
     lean_file::String;
@@ -945,7 +1003,9 @@ end
 """
     import_coq_certificate(coq_file::String; expected_certificate_hash=nothing, expected_obligation_id=nothing) -> ProofCertificate
 
-Import a completed Coq proof file and check for Admitted-free status.
+Import a completed Coq proof file and check that it is Admitted-free AND
+contains an actual property theorem (not just the certificate-hash witness
+boilerplate or an empty file).
 """
 function import_coq_certificate(
     coq_file::String;
@@ -1000,7 +1060,9 @@ end
 """
     import_isabelle_certificate(thy_file::String; expected_certificate_hash=nothing, expected_obligation_id=nothing) -> ProofCertificate
 
-Import a completed Isabelle/HOL proof file and check for oops-free status.
+Import a completed Isabelle/HOL proof file and check that it is oops-free AND
+contains an actual property theorem/lemma (not just the certificate-hash
+witness boilerplate or an empty file).
 """
 function import_isabelle_certificate(
     thy_file::String;

--- a/test/verification/proof_export_tests.jl
+++ b/test/verification/proof_export_tests.jl
@@ -66,8 +66,9 @@ using Axiom: ProofResult
         """
         -- AXIOM_CERTIFICATE_HASH: deadbeef
         -- AXIOM_OBLIGATION_ID: feedface
-        theorem completed : True := by
-          trivial
+        theorem completed : forall x, relu x >= 0 := by
+          intro x
+          exact relu_nonneg x
         """
     )
     completed_cert = import_lean_certificate(completed_lean)
@@ -103,11 +104,113 @@ using Axiom: ProofResult
         -- AXIOM_PROOF_METHOD: pattern
         -- AXIOM_OBLIGATION_ID: $(expected_id)
 
-        theorem completed_bundle : True := by
-          trivial
+        theorem completed_bundle : forall x, sum(softmax(x)) == 1.0 := by
+          intro x
+          exact softmax_sum_one x
         """
     )
     reconciled = reconcile_proof_bundle(bundle["manifest"])
     @test reconciled["obligations"][1]["assistant_reports"]["lean"]["status"] == "complete"
     @test reconciled["obligations"][1]["status"] == "interactive_required"
+end
+
+@testset "Proof Assistant Import Rejects Vacuous/Empty Proofs (G03)" begin
+    # An empty file (or a file with only certificate-hash/obligation-id
+    # metadata comments and no theorem at all) must NOT be reported as
+    # verified merely because it contains no sorry/Admitted/oops tokens.
+    empty_dir = mktempdir()
+
+    empty_lean = joinpath(empty_dir, "empty.lean")
+    write(empty_lean, "")
+    empty_cert = import_lean_certificate(empty_lean)
+    @test empty_cert.status != :proven
+    empty_report = proof_assistant_obligation_report(empty_lean, :lean)
+    @test empty_report["status"] == "incomplete" || empty_report["status"] == "missing_metadata"
+    @test empty_report["has_statement"] == false
+
+    metadata_only_lean = joinpath(empty_dir, "metadata_only.lean")
+    write(
+        metadata_only_lean,
+        """
+        -- AXIOM_CERTIFICATE_HASH: deadbeef
+        -- AXIOM_OBLIGATION_ID: feedface
+        """
+    )
+    metadata_only_cert = import_lean_certificate(metadata_only_lean)
+    @test metadata_only_cert.status != :proven
+    metadata_only_report = proof_assistant_obligation_report(metadata_only_lean, :lean)
+    @test metadata_only_report["status"] == "incomplete"
+    @test metadata_only_report["has_statement"] == false
+
+    # A trivial/vacuous theorem (`theorem foo : True := trivial`) contains no
+    # sorry/Admitted/oops escape token, but it also proves nothing about the
+    # claimed property -- it must be rejected exactly like the empty case.
+    trivial_lean = joinpath(empty_dir, "trivial.lean")
+    write(
+        trivial_lean,
+        """
+        -- AXIOM_CERTIFICATE_HASH: deadbeef
+        -- AXIOM_OBLIGATION_ID: feedface
+        theorem foo : True := trivial
+        """
+    )
+    trivial_cert = import_lean_certificate(trivial_lean)
+    @test trivial_cert.status != :proven
+    trivial_report = proof_assistant_obligation_report(trivial_lean, :lean)
+    @test trivial_report["status"] == "incomplete"
+    @test trivial_report["has_statement"] == false
+    @test trivial_report["unresolved"] == 0  # confirms rejection is NOT just token-scan
+
+    trivial_coq = joinpath(empty_dir, "trivial.v")
+    write(
+        trivial_coq,
+        """
+        (* AXIOM_CERTIFICATE_HASH: deadbeef *)
+        (* AXIOM_OBLIGATION_ID: feedface *)
+        Theorem foo : True.
+        Proof.
+          exact I.
+        Qed.
+        """
+    )
+    trivial_coq_cert = import_coq_certificate(trivial_coq)
+    @test trivial_coq_cert.status != :proven
+    trivial_coq_report = proof_assistant_obligation_report(trivial_coq, :coq)
+    @test trivial_coq_report["status"] == "incomplete"
+    @test trivial_coq_report["has_statement"] == false
+
+    trivial_thy = joinpath(empty_dir, "trivial.thy")
+    write(
+        trivial_thy,
+        """
+        (* AXIOM_CERTIFICATE_HASH: deadbeef *)
+        (* AXIOM_OBLIGATION_ID: feedface *)
+        lemma foo: "True"
+          by simp
+        """
+    )
+    trivial_isabelle_cert = import_isabelle_certificate(trivial_thy)
+    @test trivial_isabelle_cert.status != :proven
+    trivial_isabelle_report = proof_assistant_obligation_report(trivial_thy, :isabelle)
+    @test trivial_isabelle_report["status"] == "incomplete"
+    @test trivial_isabelle_report["has_statement"] == false
+
+    # Sanity check: a real (non-vacuous) property theorem with no escape
+    # tokens IS accepted -- the fix must not reject genuine proofs.
+    real_lean = joinpath(empty_dir, "real.lean")
+    write(
+        real_lean,
+        """
+        -- AXIOM_CERTIFICATE_HASH: deadbeef
+        -- AXIOM_OBLIGATION_ID: feedface
+        theorem axiom_property_relu_nonneg : forall x, relu(x) >= 0 := by
+          intro x
+          exact relu_nonneg x
+        """
+    )
+    real_cert = import_lean_certificate(real_lean)
+    @test real_cert.status == :proven
+    real_report = proof_assistant_obligation_report(real_lean, :lean)
+    @test real_report["status"] == "complete"
+    @test real_report["has_statement"] == true
 end


### PR DESCRIPTION
## Summary

Follow-up to the merged #46 (which closed the first two P1 soundness holes). This branch was **restarted from the post-merge `main`** — it does not re-stack the squashed pilot. It closes three "proof honesty" gaps and captures the initiative's decision record in-repo.

### G03 — proof-assistant import verification was fake (high)
`proof_export.jl` judged a Lean/Coq/Isabelle proof "complete" merely for **lacking** `sorry`/`Admitted`/`oops` — so an empty file, or `theorem foo : True := trivial`, passed as verified. Now a proof must contain **at least one substantive** (non-vacuous, non-boilerplate) theorem/lemma statement; empty/trivial proofs report `:incomplete`. *(Fixing this exposed two pre-existing test fixtures that were themselves vacuous `:= trivial` proofs — updated to substantive statements.)*

### G04 — `@prove` overclaim (high)
`dsl/prove.jl` (+ `docs/wiki/Verification.md`) documented `@prove` as "symbolic execution" / "formal verification", but it is a **substring match on the printed AST**. Relabelled honestly (experimental heuristic; **not** symbolic execution or a theorem prover; real proving is the SMT/Idris2 path). No behaviour change — every remaining mention is now an explicit negation.

### G05 — Idris2 ABI is a disconnected demo (high; honest relabel)
`src/Abi/*.idr` declare a generic surface that does **not** match the ~36 real `axiom_*` zig exports used by `src/backends/zig_ffi.jl`. Labelled as an **illustrative scaffold** (not a proof of the production FFI boundary) in each file + `ABI-FFI-README.md`, pointed at the real boundary (`zig/` + `zig_ffi.jl`), and flagged the **orphan `ffi/zig/` tree (zero `axiom_*` exports)** as a KNOWN ISSUE. Full ABI↔zig connection is tracked follow-up (Idris2 is CI-only here).

### Design record captured online
`docs/design-diary/PEPYS-DESIGN-DIARY.adoc` (the running "Samuel Pepys" decision log) and `docs/design-diary/ULTRAPLAN.adoc` (executive summary, 41-item gap register, phased plan, decision forks, estate wiring, risks).

## Verification (independent re-run, not self-graded)
- `Pkg.test()` on the rebased base → **670 / 670 pass** (651 + 19 new G03 assertions).
- Grep confirms no affirmative "symbolic execution" / "formal verification" claim remains attached to `@prove`.

## Residuals (tracked)
Real hybrid **Ed448+Dilithium5** certificate signing (G01 auth layer, reusing `opsm`'s `pqcrypto` crates), full Idris2-ABI↔zig connection (G05), plus the broader flagship work (Aqua/JET/Documenter, RegistryCI, panic-attack gate, RSR completeness, doc reconciliation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFC9YQ7g9gc3VnRox42Q1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPFC9YQ7g9gc3VnRox42Q1)_