### PR TITLE
fix(ci): unbreak estate-rules + A2ML gates introduced by #49

### DIFF
--- a/.github/workflows/estate-rules.yml
+++ b/.github/workflows/estate-rules.yml
@@ -4,8 +4,9 @@
 # Estate Rules — enforces hyperpolymath estate-wide conventions relevant to a
 # Julia numerics package: no-Python (banned estate-wide, replacement is
 # Julia/Rust/AffineScript), AsciiDoc-by-default under docs/ (excluding the
-# docs/wiki/ GitHub-wiki mirror, which is legitimately Markdown because
-# GitHub's wiki renderer consumes .md, not .adoc), and no V-lang (vlang.io)
+# docs/wiki/ GitHub-wiki mirror and docs/src/ Documenter source, both of which
+# are legitimately Markdown — GitHub's wiki renderer and Documenter both consume
+# .md, not .adoc), and no V-lang (vlang.io)
 # references — NOT a ban on Zig. Zig is the current estate default for
 # APIs/FFI/gateways (hyperpolymath/standards CLAUDE.md, "Estate default
 # 2026-05-28"), and Axiom.jl legitimately ships a Zig compute layer
@@ -47,15 +48,15 @@ jobs:
           fi
           echo "PASS: no Python files found"
 
-      - name: AsciiDoc by default under docs/ (excluding docs/wiki/ GitHub-wiki mirror)
+      - name: AsciiDoc by default under docs/ (excluding docs/wiki/ mirror + docs/src/ Documenter source)
         run: |
-          HITS=$(find docs -name '*.md' -type f -not -path 'docs/wiki/*' 2>/dev/null || true)
+          HITS=$(find docs -name '*.md' -type f -not -path 'docs/wiki/*' -not -path 'docs/src/*' 2>/dev/null || true)
           if [ -n "$HITS" ]; then
             echo "::error::.md files found under docs/ outside the docs/wiki/ mirror (estate rule: AsciiDoc by default):"
             echo "$HITS"
             exit 1
           fi
-          echo "PASS: no disallowed .md files under docs/ (docs/wiki/ is the GitHub-wiki Markdown mirror, exempt by design)"
+          echo "PASS: no disallowed .md files under docs/ (docs/wiki/ = GitHub-wiki mirror, docs/src/ = Documenter source; both legitimately Markdown)"
 
       - name: No V-lang references (Zig is the estate default — do not confuse the two)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ deps/
 .cache/
 build/
 dist/
+docs/Manifest.toml

--- a/.machine_readable/policies/MAINTENANCE-AXES.a2ml
+++ b/.machine_readable/policies/MAINTENANCE-AXES.a2ml
@@ -4,6 +4,8 @@
 # Canonical maintenance governance model — Axiom.jl
 
 [metadata]
+name = "axiom-maintenance-governance"
+project = "Axiom.jl"
 version = "1.0.0"
 last-updated = "2026-07-01"
 scope = "repo"

--- a/.machine_readable/policies/MAINTENANCE-CHECKLIST.a2ml
+++ b/.machine_readable/policies/MAINTENANCE-CHECKLIST.a2ml
@@ -4,6 +4,8 @@
 # Maintenance baseline (machine-readable canonical) — Axiom.jl
 
 [metadata]
+name = "axiom-maintenance-checklist"
+project = "Axiom.jl"
 version = "1.0.0"
 last-updated = "2026-07-01"
 scope = "repo"


### PR DESCRIPTION
## Summary

The tier‑2 bundle (#49) merged with two required gates red; they're now failing on `main` and will fail every subsequent PR's CI. This is a minimal follow‑up that closes both — no functional change to the tier‑2 work.

## Changes

- **`estate-rules.yml`** — the "AsciiDoc by default under `docs/`" check flagged the **Documenter source pages** (`docs/src/*.md`) that #49 added for the new docs build. Documenter's native source format is **Markdown** — it cannot consume `.adoc` — so `docs/src/` is a legitimate carve‑out, exactly like the existing `docs/wiki/` GitHub‑wiki mirror. Added `-not -path 'docs/src/*'` to the check and updated the comments/step name to document the carve‑out.
- **`.machine_readable/policies/MAINTENANCE-AXES.a2ml`** + **`MAINTENANCE-CHECKLIST.a2ml`** — A2ML validation requires an identity field (`agent-id`/`name`/`project`); these two were missing it. Added `name` + `project` to each `[metadata]` block.

## Verification (local)
- `find docs -name '*.md' -not -path 'docs/wiki/*' -not -path 'docs/src/*'` → **empty** (no disallowed `.md`; `docs/legal/*.txt` and `docs/governance/*.adoc` are unaffected).
- Both policy files now carry `name` + `project` in `[metadata]` (the exact fields the validator's error named).

## Why this happened
Two parallel workers built #49 on disjoint file‑sets; the docs worker added `docs/src/*.md` (Documenter) while the compliance worker wrote the `estate-rules` docs check — neither saw the other's additions. Caught here on the first real CI run and fixed at the workflow level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFC9YQ7g9gc3VnRox42Q1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPFC9YQ7g9gc3VnRox42Q1)_