### PR TITLE
fix(ci): make assail-classifications.a2ml conformant TOML-A2ML

### DIFF
--- a/audits/assail-classifications.a2ml
+++ b/audits/assail-classifications.a2ml
@@ -1,9 +1,30 @@
 # SPDX-License-Identifier: MPL-2.0
-# Audited legitimate residuals for `panic-attack assail`.
+# Audited legitimate residuals for `panic-attack assail` — Axiom.jl.
 # Companion audit (rationale + review): audits/audit-ffi-unsafe.adoc
+#
+# Format: TOML-A2ML (parses with tomllib; matches the estate a2ml standard
+# used by every other .a2ml in this repo and hyperpolymath/a2ml-validate-action).
+# The panic-attack user-classification registry uses an S-expression dialect,
+# so its payload is carried below as a TOML literal multiline string (''' … ''',
+# no escape processing). This keeps the file valid TOML-A2ML *and* parseable by
+# panic-attack, whose loader reads the raw file text scanning for classification
+# forms — it does not TOML-parse, and ignores everything outside a form.
+#
 # Per the user-classification protocol this registry lives separately from the
 # code under scan, so a newly-added unsafe block cannot self-suppress — the
 # suppression only holds while the cited audit is kept current.
+
+[metadata]
+name = "axiom-assail-classifications"
+project = "Axiom.jl"
+schema_version = "1.0"
+last-updated = "2026-07-01"
+scope = "repo"
+repo = "Axiom.jl"
+
+[payload]
+# panic-attack user-classification payload (S-expression dialect).
+sexpr = '''
 (assail-classifications
   (classification
     (file "crypto/src/lib.rs")
@@ -20,3 +41,4 @@
     (category "UnsafeFFI")
     (audit "audits/audit-ffi-unsafe.adoc §3")
     (rationale "Julia ccall/Libdl into the Zig compute backend; availability checked before dispatch; memory-safety-critical logic lives Zig-side")))
+'''


### PR DESCRIPTION
## What

Follow-up to #51. The Dogfood Gate's **Validate A2ML manifests** job failed on `audits/assail-classifications.a2ml` (added in #51) with:

```
##[error]Missing required identity field (agent-id, name, or project)
```

#51 was merged with that check red; this PR fixes it at source.

## Why

`a2ml-validate-action` scans **every** `*.a2ml` and expects TOML-A2ML with a self-identifying header (`name`/`project`/`schema_version`), the standard `ANCHOR.a2ml` documents for this repo. The panic-attack user-classification registry was authored in panic-attack's native **S-expression** dialect, which has no such header — so the validator rejected it.

## How

Rather than gaming the lenient (`strict:false`) check, the file is made **genuinely** TOML-A2ML conformant:

- Real `[metadata]` header: `name` / `project` / `schema_version` (mirrors every other `.a2ml` in the repo).
- The S-expression payload is carried in a TOML **literal multiline string** (`'''…'''`, no escape processing) under `[payload]`.

The result parses as valid TOML **and** is still consumed by panic-attack, whose loader (`load_user_classifications`, `src/assail/mod.rs`) reads the **raw file text** scanning for `(classification …)` forms — it does not TOML-parse, and ignores everything outside a form.

## Verification (local, ground-truthed)

- **TOML-A2ML validity** — Julia `TOML` stdlib parses the file; `metadata.{name,project,schema_version}` present; `payload.sexpr` holds exactly 3 classification forms.
- **Suppression preserved** — `panic-attack assail`: 18 weak_points, 5 suppressed (the 3 audited FFI/unsafe residuals `crypto/src/lib.rs` UnsafeCode + `signing.jl`/`zig_ffi.jl` UnsafeFFI, plus 2 structural ProofDrift), **0** unsuppressed critical — identical suppression to before the reformat.

No code changes; docs/config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPFC9YQ7g9gc3VnRox42Q1)_