### PR TITLE
fix(ci): reword flagship-rubric to not trip the estate V-lang grep

### DIFF
--- a/docs/flagship-rubric.adoc
+++ b/docs/flagship-rubric.adoc
@@ -112,7 +112,8 @@ bar. `[auto]` = enforced by `just quality`; `[review]` = human/agent-judged
   manifests` green (every `.a2ml` self-identifies; even a panic-attack
   S-expression registry is TOML-A2ML-wrapped, per Axiom PR #52).
 * `estate-rules` green: no Python; AsciiDoc-by-default under `docs/` (except
-  `docs/wiki/` + `docs/src/`); no V-lang (Zig is allowed and encouraged).
+  `docs/wiki/` + `docs/src/`); the banned legacy V language absent (Zig, its
+  estate replacement, is allowed and encouraged).
 * Licence correct for the repo's classification `[review]` — MPL-2.0 sole-owner
   default; NEVER an automated licence edit.
 * SPDX headers on all source files (authored from birth, never bulk-swept).


### PR DESCRIPTION
## What

Follow-up to #53. The `estate-rules` **"No V-lang references"** job failed on `docs/flagship-rubric.adoc` (added in #53), which merged red.

## Why

That check greps `*.adoc` prose for the banned-language token. Dimension 8 of the rubric literally read `no V-lang (...)` — so a document *describing* the estate rule tripped the rule. (`estate-rules.yml:61`, pattern `vlang|v-lang|V-lang|asdf-vlang`, `--include='*.adoc'`.)

## How

Reworded to "the banned legacy V language absent (Zig, its estate replacement, is allowed and encouraged)" — identical meaning, no banned token. The gate itself is unchanged (a policy-enforcement gate; not weakened here).

## Verification

Ran the exact estate-rules greps locally against the working tree:
- V-lang grep → **PASS** (0 matches)
- Python find → **PASS**
- `docs/*.md` (excluding `docs/wiki/`, `docs/src/`) → **PASS**

No code changes; one line of docs prose.

## Note

The `.adoc`-prose inclusion in the V-lang string grep means *any* estate document that discusses the V-language ban (or names the `check-no-vlang.sh` guard) will trip it. Left as-is here (rewording is the minimal fix), but flagged for a possible estate-wide refinement — the canonical V detection is `.v`/`v.mod` files (hypatia), not prose mentions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPFC9YQ7g9gc3VnRox42Q1)_