### PR TITLE
ci: Secret Scanner caller must grant the reusable's job permissions

### DIFF
--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -15,5 +15,9 @@ permissions:
 
 jobs:
   scan:
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
     uses: hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@d135b05bfc647d0c0fbfedc7e80f37ea50f49236
     secrets: inherit


### PR DESCRIPTION
Adds `pull-requests: write` + `actions: read` to the `scan` job so the standards secret-scanner reusable's gitleaks job can start. A called workflow cannot exceed the caller's grant; without this the run dies at startup (`startup_failure`, 0s) — the estate-wide Secret Scanner red.

Mechanical caller-side fix, mirrors hyperpolymath/standards#472. No behaviour change beyond letting the scan run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)