### PR TITLE
feat(tensor): wire tensor arithmetic; fix stale Rust→Zig backend wiki

### DIFF
--- a/.github/workflows/julia-test.yml
+++ b/.github/workflows/julia-test.yml
@@ -52,6 +52,11 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+        with:
+          # Required when the action is SHA-pinned: it can only infer the
+          # toolchain from a tag ref (e.g. @stable), so a SHA pin needs it
+          # explicitly or the run fails with "'toolchain' is a required input".
+          toolchain: stable
 
       - name: Cache Cargo (crypto shim)
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -83,6 +88,11 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+        with:
+          # Required when the action is SHA-pinned: it can only infer the
+          # toolchain from a tag ref (e.g. @stable), so a SHA pin needs it
+          # explicitly or the run fails with "'toolchain' is a required input".
+          toolchain: stable
 
       - name: Cache Cargo (crypto shim)
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4

--- a/docs/wiki/Roadmap-TODOs.md
+++ b/docs/wiki/Roadmap-TODOs.md
@@ -6,7 +6,7 @@ This page consolidates planned work and in-code TODOs for Axiom.jl. It is a livi
 ## Release Roadmap
 
 - v0.1: Core framework, DSL, verification basics (shipped).
-- v0.2: Full Rust backend, GPU support.
+- v0.2: Full Zig backend, GPU support.
 - v0.3: Hugging Face integration, model zoo.
 - v0.4: Advanced proofs, SMT integration.
 - v1.0: Production readiness, industry certifications.
@@ -23,9 +23,9 @@ Source: `README.adoc`.
 
 ### Stage 2: Backend Parity and Performance (v0.2)
 
-- Rust backend feature parity for core ops (matmul, conv, norms, activations).
+- Zig backend feature parity for core ops (matmul, conv, norms, activations).
 - Establish GPU abstraction hooks (CUDA/ROCm planned).
-- Add benchmarking + regressions for Rust vs Julia.
+- Add benchmarking + regressions for Zig vs Julia.
 
 ### Stage 3: Ecosystem and Model Zoo (v0.3)
 
@@ -65,25 +65,27 @@ Source: `docs/wiki/Framework-Comparison.md`.
 
 ## Backend Roadmap
 
-- CUDA and Metal Rust backends (planned).
+- CUDA / ROCm / Metal GPU backends via Julia extension packages
+  (`ext/AxiomCUDAExt.jl`, `ext/AxiomAMDGPUExt.jl`, `ext/AxiomMetalExt.jl`).
 - GPU performance and kernel optimization.
 
-Source: `docs/wiki/Rust-Backend.md`.
+The native CPU compute backend is **Zig** (`zig/`, `src/backends/zig_ffi.jl`);
+Rust is used only for the crypto signing shim (`crypto/`).
 
 ## Open TODOs in Code
 
 - SMT solver integration: `src/dsl/prove.jl`.
 - Proof serialization: `src/dsl/prove.jl`.
 - Optimization passes (fusion, mixed precision, Float16): `src/backends/abstract.jl`, `src/dsl/pipeline.jl`.
-- Rust codegen/compile hooks: `src/backends/abstract.jl`.
+- Zig FFI/compile hooks: `src/backends/abstract.jl`, `src/backends/zig_ffi.jl`.
 - CUDA op lowering: `src/backends/abstract.jl`.
 
 ## Maintainer Coverage Gaps
 
 Maintainership is marked TBD in:
 - Core Julia implementation
-- Rust backend
-- Zig backend
+- Zig compute backend (`zig/`, `src/backends/zig_ffi.jl`)
+- Rust crypto signing shim (`crypto/`)
 - Verification (@ensure, @prove, certificates)
 - Documentation
 - CI/CD

--- a/src/Axiom.jl
+++ b/src/Axiom.jl
@@ -73,6 +73,7 @@ using Serialization
 # Core type system
 include("types/tensor.jl")
 include("types/shapes.jl")
+include("types/math.jl")   # Tensor arithmetic (+, -, scalar/mat *, sum, adjoint)
 
 # Layer abstractions
 include("layers/abstract.jl")

--- a/src/types/math.jl
+++ b/src/types/math.jl
@@ -37,6 +37,3 @@ end
 function Base.adjoint(t::Tensor{T, 2, S}) where {T, S}
     return Tensor(collect(t.data'))
 end
-
-# 7. Broadcasters/Forwarding for activations
-(t::Tensor)(x) = t.data(x) # Handle case where layer itself is called (though usually layers wrap tensors)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -694,6 +694,23 @@ using JSON
         @test_throws EnsureViolation @ensure sum(x) ≈ 2.0 "Wrong sum"
     end
 
+    @testset "Tensor Arithmetic" begin
+        a = Axiom.Tensor(Float32[1 2; 3 4])
+        b = Axiom.Tensor(Float32[5 6; 7 8])
+
+        @test (a + b).data == Float32[6 8; 10 12]
+        @test (b - a).data == Float32[4 4; 4 4]
+        @test (a * 2.0f0).data == Float32[2 4; 6 8]
+        @test (2.0f0 * a).data == Float32[2 4; 6 8]
+        @test (a * b).data == Float32[1 2; 3 4] * Float32[5 6; 7 8]
+        @test sum(a) == 10.0f0
+        @test adjoint(a).data == permutedims(Float32[1 2; 3 4])
+
+        # Results are Tensors, not raw arrays
+        @test (a + b) isa Axiom.Tensor
+        @test (a * b) isa Axiom.Tensor
+    end
+
     @testset "Compile-Time Shape Verification" begin
         # The @axiom macro runs _verify_axiom_shapes during expansion; test it
         # directly on parsed bodies (a struct can't be defined in local scope).


### PR DESCRIPTION
## Summary

Two honesty/completeness fixes surfaced by the flagship audit (both in scope, both verified).

## 1. Wire the orphaned `types/math.jl` (dead code → live capability)

`src/types/math.jl` defined `Tensor` arithmetic — `+`, `-`, scalar and matrix `*`, `sum`, `adjoint` — but was **never `include`d**, so it was unreachable dead code. This wires it in, and drops its one broken method: `(t::Tensor)(x) = t.data(x)`, which tried to call a data array as a function.

- `src/Axiom.jl`: `include("types/math.jl")` after `tensor.jl`/`shapes.jl`.
- `src/types/math.jl`: removed the broken callable; arithmetic unchanged.
- `test/runtests.jl`: new **"Tensor Arithmetic"** testset (element-wise add/sub, scalar mul both sides, 2D matmul, `sum`, `adjoint`, and that results stay `Tensor`s).

## 2. Fix the stale "Rust backend" wiki

`docs/wiki/Roadmap-TODOs.md` mislabelled the **Zig** compute backend as "Rust" in six places and linked a non-existent `docs/wiki/Rust-Backend.md`. The real native backend is Zig (`zig/`, `src/backends/zig_ffi.jl`); Rust is used **only** for the crypto signing shim (`crypto/`).

- Corrected all six "Rust backend" mislabels → Zig.
- Replaced the broken `Rust-Backend.md` link with the real Zig source references.
- Fixed the GPU roadmap to cite the actual extension packages (`ext/AxiomCUDAExt.jl`, `ext/AxiomAMDGPUExt.jl`, `ext/AxiomMetalExt.jl`).
- Clarified the maintainer-coverage list (Zig compute backend vs. Rust crypto shim).

## Verification

- Full suite: **`Axiom.jl | 747 747` — All tests passed!** (738 → 747, +9 from the new arithmetic tests; no regression from the new `Base.*` overloads).
- Smoke-tested the arithmetic independently before wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFC9YQ7g9gc3VnRox42Q1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPFC9YQ7g9gc3VnRox42Q1)_