### PR TITLE
fix(ci): re-point validate-action references at the ecosystem repos

### DIFF
--- a/.github/workflows/dogfood-gate.yml
+++ b/.github/workflows/dogfood-gate.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Validate A2ML manifests
         if: steps.detect.outputs.count > 0
-        uses: hyperpolymath/a2ml-validate-action@b2f28c39491c0d1ff131b8fb9e197bfea79e411e # main
+        uses: hyperpolymath/a2ml-ecosystem/validate-action@aa4b836bd969df2bc58128cb8e3d20bbc88d5e79 # main
         with:
           path: '.'
           strict: 'false'
@@ -86,7 +86,7 @@ jobs:
 
       - name: Validate K9 contracts
         if: steps.detect.outputs.k9_count > 0
-        uses: hyperpolymath/k9-validate-action@f985acb62d1ed46a4b3434dc6cb148dad95cf62d # main
+        uses: hyperpolymath/k9-ecosystem/validate-action@89f3c2702f4f650a92aa7411502f38da06abd562 # main
         with:
           path: '.'
           strict: 'false'


### PR DESCRIPTION
`hyperpolymath/k9-validate-action` and `hyperpolymath/a2ml-validate-action` **no longer exist as standalone repositories**. Both were consolidated into `k9-ecosystem` / `a2ml-ecosystem` as real top-level directories and the originals deleted.

**The content is intact** — 302 and 306 files respectively. Only these references are stale.

Any workflow reaching them fails at job setup:

```
Unable to resolve action hyperpolymath/k9-validate-action, repository not found
```

## The fix — a path change, not a restore

GitHub resolves an action held in a **subdirectory** as `owner/repo/path@ref`:

```diff
- uses: hyperpolymath/a2ml-validate-action@<old-sha>
+ uses: hyperpolymath/a2ml-ecosystem/validate-action@aa4b836b
- uses: hyperpolymath/k9-validate-action@<old-sha>
+ uses: hyperpolymath/k9-ecosystem/validate-action@89f3c270
```

Both targets verified to hold a real `action.yml` — *Validate A2ML Manifests* and *Validate K9 Configurations*.

## How this stayed hidden

`dogfood-gate.yml` was itself **invalid YAML** in 71 repos, so the workflow had never run and never attempted to resolve these actions. Repairing the parse error exposed the stale reference underneath — one layer of silent breakage concealing another.

## Verified before push

- every edited file still parses and still yields a `jobs:` mapping
- **no `*-validate-action@` reference remains**
- 1 file(s) changed, all under `.github/workflows`

🤖 Generated with [Claude Code](https://claude.com/claude-code)