### PR TITLE
fix(ci): repair workflow-linter.yml — GitHub cannot parse it, so it has never run

### DIFF
--- a/.github/workflows/workflow-linter.yml
+++ b/.github/workflows/workflow-linter.yml
@@ -55,7 +55,7 @@ jobs:
           done
           if [ $failed -eq 1 ]; then
             echo "Add 'permissions:
-  contents: read' at workflow level"
+            contents: read' at workflow level"
             exit 1
           fi
           echo "All workflows have permissions declared"


### PR DESCRIPTION
`.github/workflows/workflow-linter.yml` is **invalid YAML**. GitHub refuses it at parse time, so it produces **no run, no check-run, no annotation and no log** — not a red X, an **absence**.

The tell: the Actions API reports the workflow's `name` as its **file path** instead of its `name:`.

```
name = ".github/workflows/workflow-linter.yml"
path = ".github/workflows/workflow-linter.yml"        <- name == path
```

## The repair is purely positional

No step, command or argument is altered. Depending on the file it is one of:

- a step appended at **job level** (2-space indent) moved back inside the preceding job's `steps:` list; or
- a multi-line shell string whose continuation fell out of its `run: |` block scalar, re-indented so it stays inside. **YAML strips that indent again when parsing**, so the shell receives the identical string.

## Verified before push, not assumed

- the file **parses** and yields a `jobs:` mapping
- **every `- name:` present before is still a step after** — no step lost
- **exactly one file changed**

## Scope

Part of a measured estate-wide repair: **211 invalid workflow files across 116 repos**, confirmed by the Actions API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)