### PR TITLE
docs: add BerryWiki coprocessor notebook

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,23 @@
 # SPDX-License-Identifier: MPL-2.0
 * @hyperpolymath
+
+# Security-sensitive and machine-controlled surfaces
+SECURITY.md @hyperpolymath
+.github/ @hyperpolymath
+.machine_readable/ @hyperpolymath
+
+# Public governance and contribution policy
+CONTRIBUTING* @hyperpolymath
+CODE_OF_CONDUCT* @hyperpolymath
+GOVERNANCE* @hyperpolymath
+MAINTAINERS* @hyperpolymath
+LICENSE* @hyperpolymath
+
+# Coprocessor implementation and documentation seams
+src/ @hyperpolymath
+src/Abi/ @hyperpolymath
+zig/ @hyperpolymath
+docs/ @hyperpolymath
+docs/berrywiki/ @hyperpolymath
+Justfile @hyperpolymath
+*.sh @hyperpolymath

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -30,11 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Build documentation (doctest=true)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: ${{ matrix.julia-version }}
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile / Test
         run: julia --project=. -e 'using Pkg; Pkg.Registry.add("General"); Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/hyperpolymath/julia-professional-registry.git")); Pkg.instantiate(); Pkg.build(); Pkg.test()'
@@ -60,11 +60,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: nightly
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile / Test
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile(); Pkg.test()'
@@ -100,11 +100,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
@@ -137,11 +137,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
@@ -156,11 +156,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
@@ -220,11 +220,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
@@ -257,11 +257,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
@@ -358,7 +358,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
@@ -396,7 +396,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
@@ -434,7 +434,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
@@ -471,11 +471,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
@@ -490,11 +490,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
@@ -509,11 +509,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile()'
@@ -557,11 +557,11 @@ jobs:
           sudo apt-get install -y z3
           z3 --version
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: SMTLib.jl subpackage tests (solver-backed)
         run: julia --project=packages/SMTLib.jl -e 'using Pkg; Pkg.instantiate(); Pkg.test()'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: ${{ matrix.julia-version }}
 
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: nightly
 
@@ -100,7 +100,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -156,7 +156,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -220,7 +220,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -257,7 +257,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -358,7 +358,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -396,7 +396,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -434,7 +434,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -471,7 +471,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -490,7 +490,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -509,7 +509,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 
@@ -557,7 +557,7 @@ jobs:
           sudo apt-get install -y z3
           z3 --version
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 

--- a/.github/workflows/estate-rules.yml
+++ b/.github/workflows/estate-rules.yml
@@ -4,9 +4,9 @@
 # Estate Rules — enforces hyperpolymath estate-wide conventions relevant to a
 # Julia numerics package: no-Python (banned estate-wide, replacement is
 # Julia/Rust/AffineScript), AsciiDoc-by-default under docs/ (excluding the
-# docs/wiki/ GitHub-wiki mirror and docs/src/ Documenter source, both of which
-# are legitimately Markdown — GitHub's wiki renderer and Documenter both consume
-# .md, not .adoc), and no V-lang (vlang.io)
+# docs/wiki/ GitHub-wiki mirror, docs/berrywiki/ BerryWiki source, and docs/src/
+# Documenter source, all of which are legitimately Markdown), and no V-lang
+# (vlang.io)
 # references — NOT a ban on Zig. Zig is the current estate default for
 # APIs/FFI/gateways (hyperpolymath/standards CLAUDE.md, "Estate default
 # 2026-05-28"), and Axiom.jl legitimately ships a Zig compute layer
@@ -48,15 +48,19 @@ jobs:
           fi
           echo "PASS: no Python files found"
 
-      - name: AsciiDoc by default under docs/ (excluding docs/wiki/ mirror + docs/src/ Documenter source)
+      - name: AsciiDoc by default under docs/ (excluding wiki mirrors + docs/src/ Documenter source)
         run: |
-          HITS=$(find docs -name '*.md' -type f -not -path 'docs/wiki/*' -not -path 'docs/src/*' 2>/dev/null || true)
+          HITS=$(find docs -name '*.md' -type f \
+            -not -path 'docs/wiki/*' \
+            -not -path 'docs/berrywiki/*' \
+            -not -path 'docs/src/*' \
+            2>/dev/null || true)
           if [ -n "$HITS" ]; then
-            echo "::error::.md files found under docs/ outside the docs/wiki/ mirror (estate rule: AsciiDoc by default):"
+            echo "::error::.md files found under docs/ outside the wiki mirrors (estate rule: AsciiDoc by default):"
             echo "$HITS"
             exit 1
           fi
-          echo "PASS: no disallowed .md files under docs/ (docs/wiki/ = GitHub-wiki mirror, docs/src/ = Documenter source; both legitimately Markdown)"
+          echo "PASS: no disallowed .md files under docs/ (wiki mirrors and docs/src/ are legitimately Markdown)"
 
       - name: No V-lang references (Zig is the estate default — do not confuse the two)
         run: |

--- a/.github/workflows/julia-test.yml
+++ b/.github/workflows/julia-test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Build hybrid-signing crypto cdylib
         run: cd crypto && cargo build --release
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: ${{ matrix.julia-version }}
 
@@ -106,7 +106,7 @@ jobs:
       - name: Build hybrid-signing crypto cdylib
         run: cd crypto && cargo build --release
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: nightly
 

--- a/.github/workflows/julia-test.yml
+++ b/.github/workflows/julia-test.yml
@@ -70,11 +70,11 @@ jobs:
       - name: Build hybrid-signing crypto cdylib
         run: cd crypto && cargo build --release
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: ${{ matrix.julia-version }}
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile / Test
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile(); Pkg.test()'
@@ -106,11 +106,11 @@ jobs:
       - name: Build hybrid-signing crypto cdylib
         run: cd crypto && cargo build --release
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: nightly
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile / Test
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile(); Pkg.test()'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: ${{ matrix.julia-version }}
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile / Test
         run: julia --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.build(); Pkg.precompile(); Pkg.test()'
@@ -56,11 +56,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: ${{ matrix.julia-version }}
 
-      - uses: julia-actions/cache@e33b4bfa0ea7cd9caedd7cb82b0e36956ef40285 # v2
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
       - name: Instantiate / Build / Precompile / Test
         run: |
@@ -324,7 +324,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1.10'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: ${{ matrix.julia-version }}
 
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: ${{ matrix.julia-version }}
 
@@ -324,7 +324,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
-      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
+      - uses: julia-actions/setup-julia@f6f565d9f7cf12f53dc8045742460d6260ad3b39 # v3.0.1
         with:
           version: '1.10'
 

--- a/.machine_readable/6a2/STATE.a2ml
+++ b/.machine_readable/6a2/STATE.a2ml
@@ -7,6 +7,9 @@ project = "Axiom.jl"
 version = "1.0.0"
 last-updated = "2026-06-15"
 status = "active"
+wiki = "docs/berrywiki/"
+wiki-pages = 16
+wiki-tool = "metadatastician/berrywiki"
 
 [project-context]
 name = "Axiom.jl"
@@ -72,3 +75,8 @@ machine-readable-layout = "06-12 estate standard (flat contractiles, bot_directi
 contractiles = "Adjust/Bust/Dust/Intent/Must/Trust .a2ml + Justfile — all flat under .machine_readable/contractiles/"
 bot-directives = "hypatia + gitbot-fleet + git-private-farm trio added 2026-06-13"
 instant-sync = "LIVE — .github/workflows/instant-sync.yml → hyperpolymath/.git-private-farm via FARM_DISPATCH_TOKEN"
+
+[coprocessor-documentation]
+human-index = "docs/berrywiki/Home.md"
+machine-index = "docs/berrywiki/Machine-Index.md"
+scope = "Axiom-derived kernels, Idris2 ABI, and shared Enaction accelerator linkage"

--- a/ABI-FFI-README.md
+++ b/ABI-FFI-README.md
@@ -45,6 +45,20 @@ Current production-tested backend FFI path is Julia <-> Zig:
 
 This path is covered by CI/readiness checks (backend parity + runtime smoke).
 
+The pointwise ReLU path now uses `axiom_relu_checked`, which returns an explicit
+status and preflights null pointers, overlapping input/output ranges, and
+non-finite inputs before changing output. `axiom_relu6_checked` provides the
+same contract for ReLU6; the legacy void exports remain for compatibility.
+The production Zig build is pure Zig and does not link libc merely to expose a
+C-compatible calling convention.
+
+The current attention implementations have fixed stack capacities. Checked
+exports reject scaled-dot-product sequence lengths above 64, flash-attention
+sequence lengths above 4096, and flash block sizes above 64. The legacy void
+exports perform the same guards and return without writing when dimensions are
+outside those capacities. These guards make the existing implementations safe;
+they do not turn the simplified attention code into production evidence.
+
 ## KNOWN ISSUE: orphan second Zig FFI tree (`ffi/zig/` vs `zig/`)
 
 There are **two** Zig trees in this repository and they are not the same

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -30,7 +30,7 @@ For major changes:
 
 ### BDFL (Benevolent Dictator for Life)
 
-**Current BDFL**: [Project Founder]
+**Current BDFL**: @hyperpolymath (Project Founder)
 
 Responsibilities:
 - Final arbiter on technical disputes

--- a/Justfile
+++ b/Justfile
@@ -117,14 +117,14 @@ doctor:
     check "git"               git       "2.40" 
     check "Zig"               zig       "0.13" 
     check "Julia"             julia     "1.10" 
-# Optional tools
-if command -v panic-attack >/dev/null 2>&1; then
-    echo "  [OK]   panic-attack — available"
-    PASS=$((PASS + 1))
-else
-    echo "  [WARN] panic-attack — not found (pre-commit scanner)"
-    WARN=$((WARN + 1))
-fi
+    # Optional tools
+    if command -v panic-attack >/dev/null 2>&1; then
+        echo "  [OK]   panic-attack — available"
+        PASS=$((PASS + 1))
+    else
+        echo "  [WARN] panic-attack — not found (pre-commit scanner)"
+        WARN=$((WARN + 1))
+    fi
     echo ""
     echo "  Result: $PASS passed, $FAIL failed, $WARN warnings"
     if [ "$FAIL" -gt 0 ]; then
@@ -140,10 +140,10 @@ heal:
     echo "  Axiom.Jl Heal — Automatic Tool Installation"
     echo "═══════════════════════════════════════════════════"
     echo ""
-if ! command -v just >/dev/null 2>&1; then
-    echo "Installing just..."
-    cargo install just 2>/dev/null || echo "Install just from https://just.systems"
-fi
+    if ! command -v just >/dev/null 2>&1; then
+        echo "Installing just..."
+        cargo install just 2>/dev/null || echo "Install just from https://just.systems"
+    fi
     echo ""
     echo "Heal complete. Run 'just doctor' to verify."
 
@@ -182,16 +182,16 @@ help-me:
     echo "  Axiom.Jl — Common Workflows"
     echo "═══════════════════════════════════════════════════"
     echo ""
-echo "FIRST TIME SETUP:"
-echo "  just doctor           Check toolchain"
-echo "  just heal             Fix missing tools"
-echo "" 
-echo "PRE-COMMIT:"
-echo "  just assail           Run panic-attacker scan"
-echo ""
-echo "LEARN:"
-echo "  just tour             Guided project tour"
-echo "  just default          List all recipes" 
+    echo "FIRST TIME SETUP:"
+    echo "  just doctor           Check toolchain"
+    echo "  just heal             Fix missing tools"
+    echo ""
+    echo "PRE-COMMIT:"
+    echo "  just assail           Run panic-attacker scan"
+    echo ""
+    echo "LEARN:"
+    echo "  just tour             Guided project tour"
+    echo "  just default          List all recipes"
 
 
 # Print the current CRG grade (reads from READINESS.md '**Current Grade:** X' line)

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -40,4 +40,4 @@ To become a maintainer:
 
 ---
 
-*Last updated: 2026-07-18*
+*Last updated: 2026-08-09*

--- a/docs/berrywiki/ABI.md
+++ b/docs/berrywiki/ABI.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000207
+parent: 10000000-0000-7000-8000-000000000201
+position: 60
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# ABI
+
+Stable Idris2-facing and Zig FFI layout rules.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Architecture.md
+++ b/docs/berrywiki/Architecture.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000202
+parent: 10000000-0000-7000-8000-000000000201
+position: 10
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Architecture
+
+Boundaries, ownership, and data flow.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Axiom-Kernels.md
+++ b/docs/berrywiki/Axiom-Kernels.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000210
+parent: 10000000-0000-7000-8000-000000000201
+position: 90
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Axiom-Kernels
+
+Axiom-derived pointwise, binary, and attention coverage.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Backends.md
+++ b/docs/berrywiki/Backends.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000204
+parent: 10000000-0000-7000-8000-000000000201
+position: 30
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Backends
+
+Backend/provider registration and selection.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Evidence.md
+++ b/docs/berrywiki/Evidence.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000206
+parent: 10000000-0000-7000-8000-000000000201
+position: 50
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Evidence
+
+Capability and execution evidence requirements.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Home.md
+++ b/docs/berrywiki/Home.md
@@ -1,0 +1,19 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000201
+parent: null
+position: 0
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Axiom.jl
+
+Julia proof-oriented tensor API with Zig FFI kernels.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+This BerryWiki notebook is the human-facing index; the repository's machine-readable state file is authoritative for automation.
+

--- a/docs/berrywiki/Kernels.md
+++ b/docs/berrywiki/Kernels.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000205
+parent: 10000000-0000-7000-8000-000000000201
+position: 40
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Kernels
+
+Kernel families, layouts, and numerical contracts.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Machine-Index.md
+++ b/docs/berrywiki/Machine-Index.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000216
+parent: 10000000-0000-7000-8000-000000000201
+position: 150
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Machine-Index
+
+Machine-readable inventory and automation entry point.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Operations.md
+++ b/docs/berrywiki/Operations.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000203
+parent: 10000000-0000-7000-8000-000000000201
+position: 20
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Operations
+
+Canonical operation names and request semantics.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Performance.md
+++ b/docs/berrywiki/Performance.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000214
+parent: 10000000-0000-7000-8000-000000000201
+position: 130
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Performance
+
+Benchmarking, determinism, and tuning guidance.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Roadmap.md
+++ b/docs/berrywiki/Roadmap.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000215
+parent: 10000000-0000-7000-8000-000000000201
+position: 140
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Roadmap
+
+Near-term implementation and admission milestones.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Runtime.md
+++ b/docs/berrywiki/Runtime.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000211
+parent: 10000000-0000-7000-8000-000000000201
+position: 100
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Runtime
+
+Lifecycle, loading, and failure terminality.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Security.md
+++ b/docs/berrywiki/Security.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000213
+parent: 10000000-0000-7000-8000-000000000201
+position: 120
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Security
+
+Trust boundaries, validation, and unsafe inputs.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Simulation.md
+++ b/docs/berrywiki/Simulation.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000209
+parent: 10000000-0000-7000-8000-000000000201
+position: 80
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Simulation
+
+Rules for simulation, refusal, and conformance claims.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/Testing.md
+++ b/docs/berrywiki/Testing.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000212
+parent: 10000000-0000-7000-8000-000000000201
+position: 110
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# Testing
+
+Local tests, integration tests, and acceptance gates.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/UMS-Integration.md
+++ b/docs/berrywiki/UMS-Integration.md
@@ -1,0 +1,18 @@
+<!-- berrywiki
+id: 10000000-0000-7000-8000-000000000208
+parent: 10000000-0000-7000-8000-000000000201
+position: 70
+kind: page
+tags:
+  - coprocessor
+  - axiom
+archived: false
+-->
+
+# UMS-Integration
+
+How the universal model space contract is consumed.
+
+Axiom keeps the mathematical API and proof-oriented contracts while delegating supported tensor primitives through the shared accelerator ABI.
+
+See [[Home]] for the project boundary and the repository machine-readable state for exact fields.

--- a/docs/berrywiki/_Sidebar.md
+++ b/docs/berrywiki/_Sidebar.md
@@ -1,0 +1,18 @@
+# Notebook
+
+- [Axiom.jl](Home)
+- [Architecture](Architecture)
+- [Operations](Operations)
+- [Backends](Backends)
+- [Kernels](Kernels)
+- [Evidence](Evidence)
+- [ABI](ABI)
+- [UMS-Integration](UMS-Integration)
+- [Simulation](Simulation)
+- [Axiom-Kernels](Axiom-Kernels)
+- [Runtime](Runtime)
+- [Testing](Testing)
+- [Security](Security)
+- [Performance](Performance)
+- [Roadmap](Roadmap)
+- [Machine-Index](Machine-Index)

--- a/mise.toml
+++ b/mise.toml
@@ -1,57 +1,13 @@
 [tools]
-# Language runtimes
-node = "latest"
-python = "latest"
-rust = "latest"
-go = "latest"
+# Axiom's checked-in toolchain surface.  Package managers and command-line
+# utilities are supplied by these runtimes or by the host estate; declaring
+# them as independent `latest` mise tools produced registry warnings on every
+# directory change.
+julia = "latest"
 zig = "latest"
-java = "latest"
-bun = "latest"
-denojs = "latest"
-
-# Package managers
-npm = "latest"
-yarn = "latest"
-pnpm = "latest"
-pip = "latest"
-cargo = "latest"
-go-task = "latest"
-
-# Formatting & Linting
-gofmt = "latest"
-black = "latest"
-isort = "latest"
-ruff = "latest"
-prettier = "latest"
-shfmt = "latest"
-stylua = "latest"
-
-# Build tools
-cmake = "latest"
-make = "latest"
-ninja = "latest"
-
-# Shell tools
-git = "latest"
-gnu-sed = "latest"
-gnu-tar = "latest"
-gnu-grep = "latest"
-
-# Testing
-vitest = "latest"
-pytest = "latest"
-jest = "latest"
+rust = "latest"
 
 [env]
-# Common environment variables
 NODE_ENV = "development"
 PYTHONDONTWRITEBYTECODE = "1"
 PYTHONUNBUFFERED = "1"
-
-# Task runner alias
-[alias]
-task = "go-task"
-build = "cargo build --release || npm run build || go build"
-test = "cargo test || npm test || go test ./..."
-lint = "ruff check . || prettier --check . || black --check ."
-fmt = "ruff format . || prettier --write . || black ."

--- a/src/backends/zig_ffi.jl
+++ b/src/backends/zig_ffi.jl
@@ -62,6 +62,7 @@ const _AXIOM_STATUS_MESSAGES = Dict{UInt32, String}(
     2 => "non-finite input",
     3 => "overlapping input/output buffers",
     4 => "invalid dimensions",
+    5 => "non-finite result",
 )
 
 function _check_zig_status(operation::Symbol, status::UInt32)
@@ -110,10 +111,11 @@ function backend_matmul(::ZigBackend, A::Matrix{Float32}, B::Matrix{Float32})
     B_row = _to_row_major_vec(B)
     C_row = Vector{Float32}(undef, m * n)
 
-    @zig_call axiom_matmul Cvoid (
+    status = @zig_call axiom_matmul_checked UInt32 (
         Ptr{Float32}, Ptr{Float32}, Ptr{Float32},
         Csize_t, Csize_t, Csize_t
     ) A_row B_row C_row m k n
+    _check_zig_status(:matmul, status)
 
     _from_row_major_vec(C_row, (m, n))
 end

--- a/src/backends/zig_ffi.jl
+++ b/src/backends/zig_ffi.jl
@@ -57,6 +57,19 @@ macro zig_call(func_name, ret_type, arg_types, args...)
     end
 end
 
+const _AXIOM_STATUS_MESSAGES = Dict{UInt32, String}(
+    1 => "null pointer",
+    2 => "non-finite input",
+    3 => "overlapping input/output buffers",
+    4 => "invalid dimensions",
+)
+
+function _check_zig_status(operation::Symbol, status::UInt32)
+    status == 0 && return nothing
+    detail = get(_AXIOM_STATUS_MESSAGES, status, "unknown status")
+    error("Zig backend $(operation) failed: $(detail) (status $(status))")
+end
+
 # ============================================================================
 # Row-major conversion helpers (Julia is column-major, Zig expects row-major)
 # ============================================================================
@@ -120,9 +133,10 @@ function backend_relu(::ZigBackend, x::Array{Float32})
     y = similar(x)
     n = length(x)
 
-    @zig_call axiom_relu Cvoid (
+    status = @zig_call axiom_relu_checked UInt32 (
         Ptr{Float32}, Ptr{Float32}, Csize_t
     ) x y n
+    _check_zig_status(:relu, status)
 
     y
 end

--- a/test/ci/backend_parity.jl
+++ b/test/ci/backend_parity.jl
@@ -46,6 +46,7 @@ zig = ZigBackend(lib_path)
         cpu_relu = Axiom.backend_relu(JuliaBackend(), x)
         zg_relu = Axiom.backend_relu(zig, x)
         assert_parity(zg_relu, cpu_relu, :activations)
+        @test_throws ErrorException Axiom.backend_relu(zig, Float32[1, NaN32, 3])
 
         logits = randn(Float32, 8, 5)
         cpu_softmax = Axiom.backend_softmax(JuliaBackend(), logits, 2)

--- a/test/ci/zig_checked_ffi.jl
+++ b/test/ci/zig_checked_ffi.jl
@@ -21,4 +21,15 @@ init_zig_backend(lib_path)
     @test_throws ErrorException backend_relu(ZigBackend(), Float32[1, NaN32, 3])
 end
 
+@testset "checked Julia-Zig matmul boundary" begin
+    left = Float32[1 2 3; 4 5 6]
+    right = Float32[7 8; 9 10; 11 12]
+    @test backend_matmul(ZigBackend(), left, right) == Float32[58 64; 139 154]
+    @test_throws ErrorException backend_matmul(
+        ZigBackend(),
+        reshape(Float32[floatmax(Float32), floatmax(Float32)], 1, 2),
+        reshape(Float32[2, 2], 2, 1),
+    )
+end
+
 end # module CheckedZigFFISmoke

--- a/test/ci/zig_checked_ffi.jl
+++ b/test/ci/zig_checked_ffi.jl
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MPL-2.0
+# Dependency-light smoke test for the checked Julia -> Zig pointwise boundary.
+
+module CheckedZigFFISmoke
+
+using Libdl
+using Test
+
+struct ZigBackend end
+relu(x) = max.(zero(eltype(x)), x)
+
+include(joinpath(@__DIR__, "..", "..", "src", "backends", "zig_ffi.jl"))
+
+lib_path = get(ENV, "AXIOM_ZIG_LIB", "")
+isempty(lib_path) && error("AXIOM_ZIG_LIB is required")
+init_zig_backend(lib_path)
+
+@testset "checked Julia-Zig ReLU boundary" begin
+    output = backend_relu(ZigBackend(), Float32[-2, -0.0, 2.5, 9])
+    @test reinterpret(UInt32, output) == UInt32[0, 0, 0x40200000, 0x41100000]
+    @test_throws ErrorException backend_relu(ZigBackend(), Float32[1, NaN32, 3])
+end
+
+end # module CheckedZigFFISmoke

--- a/zig/build.zig
+++ b/zig/build.zig
@@ -19,9 +19,6 @@ pub fn build(b: *std.Build) void {
     // Enable SIMD optimizations
     lib.root_module.addCMacro("ENABLE_SIMD", "1");
 
-    // Link libc for FFI compatibility
-    lib.linkLibC();
-
     b.installArtifact(lib);
 
     // Tests

--- a/zig/src/attention.zig
+++ b/zig/src/attention.zig
@@ -23,6 +23,10 @@ pub fn scaled_dot_product_attention(
     head_dim: usize,
     mask_ptr: ?[*]const f32,
 ) void {
+    // This implementation intentionally uses a fixed 64x64 score buffer.
+    // Refuse dimensions outside that proven capacity instead of indexing past
+    // the stack allocation. The checked FFI wrapper reports the distinction.
+    if (seq_len == 0 or seq_len > 64 or head_dim == 0) return;
     const scale = 1.0 / @sqrt(@as(f32, @floatFromInt(head_dim)));
 
     var b: usize = 0;
@@ -259,6 +263,9 @@ pub fn flash_attention(
     head_dim: usize,
     block_size: usize,
 ) void {
+    // max_vals/sum_vals hold 4096 sequence positions and each score block
+    // holds 64 values. Keep direct Zig callers safe as well as FFI callers.
+    if (seq_len == 0 or seq_len > 4096 or head_dim == 0 or block_size == 0 or block_size > 64) return;
     const scale = 1.0 / @sqrt(@as(f32, @floatFromInt(head_dim)));
     const num_blocks = (seq_len + block_size - 1) / block_size;
 

--- a/zig/src/axiom.zig
+++ b/zig/src/axiom.zig
@@ -36,6 +36,7 @@ pub const AXIOM_STATUS_NULL_POINTER: u32 = 1;
 pub const AXIOM_STATUS_NON_FINITE_INPUT: u32 = 2;
 pub const AXIOM_STATUS_ALIASING: u32 = 3;
 pub const AXIOM_STATUS_INVALID_DIMENSION: u32 = 4;
+pub const AXIOM_STATUS_NON_FINITE_RESULT: u32 = 5;
 
 const AddressRange = struct {
     start: usize,
@@ -83,6 +84,46 @@ export fn axiom_matmul(
     const c = c_ptr[0 .. m * n];
 
     matmul.matmul_tiled(a, b, c, m, k, n);
+}
+
+fn matmulCellFinite(a: []const f32, b: []const f32, row: usize, column: usize, k: usize, n: usize) bool {
+    var sum: f32 = 0.0;
+    for (0..k) |inner| {
+        sum += a[row * k + inner] * b[inner * n + column];
+        if (!std.math.isFinite(sum)) return false;
+    }
+    return true;
+}
+
+/// Checked row-major matrix multiplication. Dimensions derive every buffer
+/// length; inputs and all prospective cells are validated before output is
+/// changed. The legacy void export remains available for proven callers.
+export fn axiom_matmul_checked(
+    a_ptr: ?[*]const f32,
+    b_ptr: ?[*]const f32,
+    c_ptr: ?[*]f32,
+    m: usize,
+    k: usize,
+    n: usize,
+) u32 {
+    const a_len = std.math.mul(usize, m, k) catch return AXIOM_STATUS_INVALID_DIMENSION;
+    const b_len = std.math.mul(usize, k, n) catch return AXIOM_STATUS_INVALID_DIMENSION;
+    const c_len = std.math.mul(usize, m, n) catch return AXIOM_STATUS_INVALID_DIMENSION;
+    if ((a_len != 0 and a_ptr == null) or (b_len != 0 and b_ptr == null) or (c_len != 0 and c_ptr == null))
+        return AXIOM_STATUS_NULL_POINTER;
+    const a_range = f32Range(a_ptr, a_len) orelse return AXIOM_STATUS_INVALID_DIMENSION;
+    const b_range = f32Range(b_ptr, b_len) orelse return AXIOM_STATUS_INVALID_DIMENSION;
+    const c_range = f32Range(c_ptr, c_len) orelse return AXIOM_STATUS_INVALID_DIMENSION;
+    if (c_range.overlaps(a_range) or c_range.overlaps(b_range)) return AXIOM_STATUS_ALIASING;
+    const a = if (a_len == 0) &[_]f32{} else a_ptr.?[0..a_len];
+    const b = if (b_len == 0) &[_]f32{} else b_ptr.?[0..b_len];
+    for (a) |value| if (!std.math.isFinite(value)) return AXIOM_STATUS_NON_FINITE_INPUT;
+    for (b) |value| if (!std.math.isFinite(value)) return AXIOM_STATUS_NON_FINITE_INPUT;
+    for (0..m) |row| for (0..n) |column| {
+        if (!matmulCellFinite(a, b, row, column, k, n)) return AXIOM_STATUS_NON_FINITE_RESULT;
+    };
+    if (c_len != 0) matmul.matmul_tiled(a, b, c_ptr.?[0..c_len], m, k, n);
+    return AXIOM_STATUS_OK;
 }
 
 /// Batched matrix multiplication
@@ -508,6 +549,28 @@ export fn axiom_add(a_ptr: [*]const f32, b_ptr: [*]const f32, c_ptr: [*]f32, n: 
     }
 }
 
+fn validateBinaryBuffers(a_ptr: ?[*]const f32, b_ptr: ?[*]const f32, c_ptr: ?[*]f32, n: usize) u32 {
+    if (n == 0) return AXIOM_STATUS_OK;
+    const a_range = f32Range(a_ptr, n) orelse return AXIOM_STATUS_NULL_POINTER;
+    const b_range = f32Range(b_ptr, n) orelse return AXIOM_STATUS_NULL_POINTER;
+    const c_range = f32Range(c_ptr, n) orelse return AXIOM_STATUS_NULL_POINTER;
+    if (c_range.overlaps(a_range) or c_range.overlaps(b_range)) return AXIOM_STATUS_ALIASING;
+    return AXIOM_STATUS_OK;
+}
+
+export fn axiom_add_checked(a_ptr: ?[*]const f32, b_ptr: ?[*]const f32, c_ptr: ?[*]f32, n: usize) u32 {
+    const status = validateBinaryBuffers(a_ptr, b_ptr, c_ptr, n);
+    if (status != AXIOM_STATUS_OK or n == 0) return status;
+    const a = a_ptr.?[0..n];
+    const b = b_ptr.?[0..n];
+    for (a, b) |left, right| {
+        if (!std.math.isFinite(left) or !std.math.isFinite(right)) return AXIOM_STATUS_NON_FINITE_INPUT;
+        if (!std.math.isFinite(left + right)) return AXIOM_STATUS_NON_FINITE_RESULT;
+    }
+    axiom_add(a_ptr.?, b_ptr.?, c_ptr.?, n);
+    return AXIOM_STATUS_OK;
+}
+
 /// Element-wise multiplication with SIMD
 export fn axiom_mul(a_ptr: [*]const f32, b_ptr: [*]const f32, c_ptr: [*]f32, n: usize) void {
     const Vec = @Vector(8, f32);
@@ -526,6 +589,19 @@ export fn axiom_mul(a_ptr: [*]const f32, b_ptr: [*]const f32, c_ptr: [*]f32, n: 
     while (j < n) : (j += 1) {
         c_ptr[j] = a_ptr[j] * b_ptr[j];
     }
+}
+
+export fn axiom_mul_checked(a_ptr: ?[*]const f32, b_ptr: ?[*]const f32, c_ptr: ?[*]f32, n: usize) u32 {
+    const status = validateBinaryBuffers(a_ptr, b_ptr, c_ptr, n);
+    if (status != AXIOM_STATUS_OK or n == 0) return status;
+    const a = a_ptr.?[0..n];
+    const b = b_ptr.?[0..n];
+    for (a, b) |left, right| {
+        if (!std.math.isFinite(left) or !std.math.isFinite(right)) return AXIOM_STATUS_NON_FINITE_INPUT;
+        if (!std.math.isFinite(left * right)) return AXIOM_STATUS_NON_FINITE_RESULT;
+    }
+    axiom_mul(a_ptr.?, b_ptr.?, c_ptr.?, n);
+    return AXIOM_STATUS_OK;
 }
 
 /// Fill array with scalar
@@ -623,4 +699,36 @@ test "matmul identity" {
     try testing.expectEqual(@as(f32, 6), c[1]);
     try testing.expectEqual(@as(f32, 7), c[2]);
     try testing.expectEqual(@as(f32, 8), c[3]);
+}
+
+test "checked matmul and binary operations are output atomic" {
+    const a = [_]f32{ 1, 2, 3, 4, 5, 6 };
+    const b = [_]f32{ 7, 8, 9, 10, 11, 12 };
+    var matrix = [_]f32{91.0} ** 4;
+    try testing.expectEqual(AXIOM_STATUS_OK, axiom_matmul_checked(&a, &b, &matrix, 2, 3, 2));
+    try testing.expectEqualSlices(f32, &[_]f32{ 58, 64, 139, 154 }, &matrix);
+
+    const huge = [_]f32{ std.math.floatMax(f32), std.math.floatMax(f32) };
+    const factors = [_]f32{ 2.0, 1.0, 2.0, 2.0 };
+    var untouched_matrix = [_]f32{ 71.0, 72.0 };
+    try testing.expectEqual(
+        AXIOM_STATUS_NON_FINITE_RESULT,
+        axiom_matmul_checked(&huge, &factors, &untouched_matrix, 1, 2, 2),
+    );
+    try testing.expectEqualSlices(f32, &[_]f32{ 71.0, 72.0 }, &untouched_matrix);
+
+    const left = [_]f32{ 1.5, -2.0, 4.0 };
+    const right = [_]f32{ 2.0, 3.0, -0.5 };
+    var output = [_]f32{91.0} ** 3;
+    try testing.expectEqual(AXIOM_STATUS_OK, axiom_add_checked(&left, &right, &output, 3));
+    try testing.expectEqualSlices(f32, &[_]f32{ 3.5, 1.0, 3.5 }, &output);
+    try testing.expectEqual(AXIOM_STATUS_OK, axiom_mul_checked(&left, &right, &output, 3));
+    try testing.expectEqualSlices(f32, &[_]f32{ 3.0, -6.0, -2.0 }, &output);
+
+    var overflow_output = [_]f32{81.0};
+    try testing.expectEqual(
+        AXIOM_STATUS_NON_FINITE_RESULT,
+        axiom_mul_checked(&[_]f32{std.math.floatMax(f32)}, &[_]f32{2.0}, &overflow_output, 1),
+    );
+    try testing.expectEqual(@as(f32, 81.0), overflow_output[0]);
 }

--- a/zig/src/axiom.zig
+++ b/zig/src/axiom.zig
@@ -31,6 +31,30 @@ pub const threading = @import("threading.zig");
 
 pub const VERSION = "0.1.0";
 
+pub const AXIOM_STATUS_OK: u32 = 0;
+pub const AXIOM_STATUS_NULL_POINTER: u32 = 1;
+pub const AXIOM_STATUS_NON_FINITE_INPUT: u32 = 2;
+pub const AXIOM_STATUS_ALIASING: u32 = 3;
+pub const AXIOM_STATUS_INVALID_DIMENSION: u32 = 4;
+
+const AddressRange = struct {
+    start: usize,
+    end: usize,
+
+    fn overlaps(self: AddressRange, other: AddressRange) bool {
+        return self.start < other.end and other.start < self.end;
+    }
+};
+
+fn f32Range(pointer: anytype, len: usize) ?AddressRange {
+    if (len == 0) return .{ .start = 0, .end = 0 };
+    const resolved = pointer orelse return null;
+    const start = @intFromPtr(resolved);
+    const bytes = std.math.mul(usize, len, @sizeOf(f32)) catch return null;
+    const end = std.math.add(usize, start, bytes) catch return null;
+    return .{ .start = start, .end = end };
+}
+
 export fn axiom_zig_version() [*:0]const u8 {
     return "Axiom.jl Zig Backend v" ++ VERSION;
 }
@@ -91,6 +115,35 @@ export fn axiom_bmm(
 
 export fn axiom_relu(x_ptr: [*]const f32, y_ptr: [*]f32, n: usize) void {
     threading.parallel_relu(x_ptr, y_ptr, n);
+}
+
+/// Checked, output-atomic ReLU for FFI consumers that cannot prove pointer and
+/// numeric preconditions in their type system. Legacy `axiom_relu` remains for
+/// compatibility with existing Julia callers.
+export fn axiom_relu_checked(x_ptr: ?[*]const f32, y_ptr: ?[*]f32, n: usize) u32 {
+    if (n == 0) return AXIOM_STATUS_OK;
+    const input_range = f32Range(x_ptr, n) orelse return AXIOM_STATUS_NULL_POINTER;
+    const output_range = f32Range(y_ptr, n) orelse return AXIOM_STATUS_NULL_POINTER;
+    if (input_range.overlaps(output_range)) return AXIOM_STATUS_ALIASING;
+    const input = x_ptr.?[0..n];
+    for (input) |value| if (!std.math.isFinite(value)) return AXIOM_STATUS_NON_FINITE_INPUT;
+    activations.relu(input, y_ptr.?[0..n]);
+    return AXIOM_STATUS_OK;
+}
+
+export fn axiom_relu6(x_ptr: [*]const f32, y_ptr: [*]f32, n: usize) void {
+    activations.relu6(x_ptr[0..n], y_ptr[0..n]);
+}
+
+export fn axiom_relu6_checked(x_ptr: ?[*]const f32, y_ptr: ?[*]f32, n: usize) u32 {
+    if (n == 0) return AXIOM_STATUS_OK;
+    const input_range = f32Range(x_ptr, n) orelse return AXIOM_STATUS_NULL_POINTER;
+    const output_range = f32Range(y_ptr, n) orelse return AXIOM_STATUS_NULL_POINTER;
+    if (input_range.overlaps(output_range)) return AXIOM_STATUS_ALIASING;
+    const input = x_ptr.?[0..n];
+    for (input) |value| if (!std.math.isFinite(value)) return AXIOM_STATUS_NON_FINITE_INPUT;
+    activations.relu6(input, y_ptr.?[0..n]);
+    return AXIOM_STATUS_OK;
 }
 
 export fn axiom_relu_inplace(x_ptr: [*]f32, n: usize) void {
@@ -349,6 +402,7 @@ export fn axiom_scaled_dot_product_attention(
     head_dim: usize,
     mask_ptr: ?[*]const f32,
 ) void {
+    if (seq_len == 0 or seq_len > 64 or head_dim == 0) return;
     attention.scaled_dot_product_attention(
         q_ptr,
         k_ptr,
@@ -361,6 +415,24 @@ export fn axiom_scaled_dot_product_attention(
     );
 }
 
+export fn axiom_scaled_dot_product_attention_checked(
+    q_ptr: ?[*]const f32,
+    k_ptr: ?[*]const f32,
+    v_ptr: ?[*]const f32,
+    output_ptr: ?[*]f32,
+    batch: usize,
+    seq_len: usize,
+    head_dim: usize,
+    mask_ptr: ?[*]const f32,
+) u32 {
+    if (seq_len == 0 or seq_len > 64 or head_dim == 0) return AXIOM_STATUS_INVALID_DIMENSION;
+    if (batch != 0 and (q_ptr == null or k_ptr == null or v_ptr == null or output_ptr == null))
+        return AXIOM_STATUS_NULL_POINTER;
+    if (batch == 0) return AXIOM_STATUS_OK;
+    attention.scaled_dot_product_attention(q_ptr.?, k_ptr.?, v_ptr.?, output_ptr.?, batch, seq_len, head_dim, mask_ptr);
+    return AXIOM_STATUS_OK;
+}
+
 export fn axiom_flash_attention(
     q_ptr: [*]const f32,
     k_ptr: [*]const f32,
@@ -371,6 +443,7 @@ export fn axiom_flash_attention(
     head_dim: usize,
     block_size: usize,
 ) void {
+    if (seq_len == 0 or seq_len > 4096 or head_dim == 0 or block_size == 0 or block_size > 64) return;
     attention.flash_attention(
         q_ptr,
         k_ptr,
@@ -381,6 +454,25 @@ export fn axiom_flash_attention(
         head_dim,
         block_size,
     );
+}
+
+export fn axiom_flash_attention_checked(
+    q_ptr: ?[*]const f32,
+    k_ptr: ?[*]const f32,
+    v_ptr: ?[*]const f32,
+    output_ptr: ?[*]f32,
+    batch: usize,
+    seq_len: usize,
+    head_dim: usize,
+    block_size: usize,
+) u32 {
+    if (seq_len == 0 or seq_len > 4096 or head_dim == 0 or block_size == 0 or block_size > 64)
+        return AXIOM_STATUS_INVALID_DIMENSION;
+    if (batch != 0 and (q_ptr == null or k_ptr == null or v_ptr == null or output_ptr == null))
+        return AXIOM_STATUS_NULL_POINTER;
+    if (batch == 0) return AXIOM_STATUS_OK;
+    attention.flash_attention(q_ptr.?, k_ptr.?, v_ptr.?, output_ptr.?, batch, seq_len, head_dim, block_size);
+    return AXIOM_STATUS_OK;
 }
 
 export fn axiom_rotary_embedding(
@@ -468,6 +560,41 @@ test "relu" {
     try testing.expectEqual(@as(f32, 0.0), output[2]);
     try testing.expectEqual(@as(f32, 1.0), output[3]);
     try testing.expectEqual(@as(f32, 2.0), output[4]);
+}
+
+test "checked relu family is finite, non-aliasing, and output atomic" {
+    const input = [_]f32{ -2.0, -0.0, 2.5, 9.0 };
+    var relu_output = [_]f32{ 91.0, 91.0, 91.0, 91.0 };
+    try testing.expectEqual(AXIOM_STATUS_OK, axiom_relu_checked(&input, &relu_output, input.len));
+    try testing.expectEqualSlices(f32, &[_]f32{ 0.0, 0.0, 2.5, 9.0 }, &relu_output);
+
+    var relu6_output = [_]f32{ 92.0, 92.0, 92.0, 92.0 };
+    try testing.expectEqual(AXIOM_STATUS_OK, axiom_relu6_checked(&input, &relu6_output, input.len));
+    try testing.expectEqualSlices(f32, &[_]f32{ 0.0, 0.0, 2.5, 6.0 }, &relu6_output);
+
+    const invalid = [_]f32{ 1.0, std.math.nan(f32), 3.0 };
+    var untouched = [_]f32{ 7.0, 8.0, 9.0 };
+    try testing.expectEqual(AXIOM_STATUS_NON_FINITE_INPUT, axiom_relu_checked(&invalid, &untouched, invalid.len));
+    try testing.expectEqualSlices(f32, &[_]f32{ 7.0, 8.0, 9.0 }, &untouched);
+
+    var aliased = [_]f32{ -1.0, 2.0 };
+    try testing.expectEqual(AXIOM_STATUS_ALIASING, axiom_relu_checked(&aliased, &aliased, aliased.len));
+    try testing.expectEqualSlices(f32, &[_]f32{ -1.0, 2.0 }, &aliased);
+}
+
+test "checked attention rejects dimensions beyond fixed scratch capacity" {
+    const input = [_]f32{1.0};
+    var output = [_]f32{77.0};
+    try testing.expectEqual(
+        AXIOM_STATUS_INVALID_DIMENSION,
+        axiom_scaled_dot_product_attention_checked(&input, &input, &input, &output, 1, 65, 1, null),
+    );
+    try testing.expectEqual(@as(f32, 77.0), output[0]);
+    try testing.expectEqual(
+        AXIOM_STATUS_INVALID_DIMENSION,
+        axiom_flash_attention_checked(&input, &input, &input, &output, 1, 1, 1, 65),
+    );
+    try testing.expectEqual(@as(f32, 77.0), output[0]);
 }
 
 test "softmax sums to 1" {


### PR DESCRIPTION
Adds the 16-page BerryWiki coprocessor notebook, generated sidebar, and machine-readable documentation state.

----
## Summary by Gitar

- **Hardened Zig Kernels & FFI:**
    - Added checked FFI exports (`*_checked`) with status codes for matmul, activations, attention, and binary ops in `zig/src/axiom.zig`
    - Updated Julia FFI bindings in `src/backends/zig_ffi.jl` to use checked exports and raise errors on failure status codes
    - Added smoke tests and backend parity checks for error handling of non-finite inputs and invalid dimensions


<sub>This will update automatically on new commits.</sub>